### PR TITLE
Add timeout config for rollupclient

### DIFF
--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -178,8 +178,8 @@ func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger, m metr
 		return nil, err
 	}
 
-	rpcTimeoutCfg := client.BaseRpcTimeout{
-		RpcTimeout: cfg.TxMgrConfig.NetworkTimeout,
+	rpcTimeoutCfg := client.BaseRPCTimeout{
+		RPCTimeout: cfg.TxMgrConfig.NetworkTimeout,
 	}
 	rollupClient, err := dial.DialRollupClientWithTimeout(context.Background(), dial.DefaultDialTimeout, l, cfg.RollupRpc, rpcTimeoutCfg)
 	if err != nil {

--- a/op-proposer/proposer/l2_output_submitter.go
+++ b/op-proposer/proposer/l2_output_submitter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-proposer/flags"
 	"github.com/ethereum-optimism/optimism/op-proposer/metrics"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/client"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
@@ -177,7 +178,10 @@ func NewL2OutputSubmitterConfigFromCLIConfig(cfg CLIConfig, l log.Logger, m metr
 		return nil, err
 	}
 
-	rollupClient, err := dial.DialRollupClientWithTimeout(context.Background(), dial.DefaultDialTimeout, l, cfg.RollupRpc)
+	rpcTimeoutCfg := client.BaseRpcTimeout{
+		RpcTimeout: cfg.TxMgrConfig.NetworkTimeout,
+	}
+	rollupClient, err := dial.DialRollupClientWithTimeout(context.Background(), dial.DefaultDialTimeout, l, cfg.RollupRpc, rpcTimeoutCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/op-service/client/rpc.go
+++ b/op-service/client/rpc.go
@@ -20,8 +20,8 @@ import (
 
 var (
 	httpRegex              = regexp.MustCompile("^http(s)?://")
-	defaultRpcTimeout      = 10 * time.Second
-	defaultRpcBatchTimeout = 20 * time.Second
+	defaultRPCTimeout      = 10 * time.Second
+	defaultRPCBatchTimeout = 20 * time.Second
 )
 
 type RPC interface {
@@ -105,12 +105,12 @@ func NewRPC(ctx context.Context, lgr log.Logger, addr string, opts ...RPCOption)
 		return nil, err
 	}
 
-	baseRPCClient := &BaseRPCClient{c: underlying, RpcTimeout: defaultRpcTimeout, RpcBatchTimeout: defaultRpcBatchTimeout}
+	baseRPCClient := &BaseRPCClient{c: underlying, RPCTimeout: defaultRPCTimeout, RPCBatchTimeout: defaultRPCBatchTimeout}
 	if cfg.rpcTimeout != nil {
-		baseRPCClient.RpcTimeout = *cfg.rpcTimeout
+		baseRPCClient.RPCTimeout = *cfg.rpcTimeout
 	}
 	if cfg.rpcBatchTimeout != nil {
-		baseRPCClient.RpcBatchTimeout = *cfg.rpcBatchTimeout
+		baseRPCClient.RPCBatchTimeout = *cfg.rpcBatchTimeout
 	}
 	var wrapped RPC = baseRPCClient
 
@@ -175,17 +175,17 @@ func IsURLAvailable(address string) bool {
 // It sets a timeout of 10s on CallContext & 20s on BatchCallContext made through it.
 type BaseRPCClient struct {
 	c               *rpc.Client
-	RpcTimeout      time.Duration
-	RpcBatchTimeout time.Duration
+	RPCTimeout      time.Duration
+	RPCBatchTimeout time.Duration
 }
 
-type BaseRpcTimeout struct {
-	RpcTimeout      time.Duration
-	RpcBatchTimeout time.Duration
+type BaseRPCTimeout struct {
+	RPCTimeout      time.Duration
+	RPCBatchTimeout time.Duration
 }
 
 func NewBaseRPCClient(c *rpc.Client) *BaseRPCClient {
-	return &BaseRPCClient{c: c, RpcTimeout: defaultRpcTimeout, RpcBatchTimeout: defaultRpcBatchTimeout}
+	return &BaseRPCClient{c: c, RPCTimeout: defaultRPCTimeout, RPCBatchTimeout: defaultRPCBatchTimeout}
 }
 
 func (b *BaseRPCClient) Close() {
@@ -193,13 +193,13 @@ func (b *BaseRPCClient) Close() {
 }
 
 func (b *BaseRPCClient) CallContext(ctx context.Context, result any, method string, args ...any) error {
-	cCtx, cancel := context.WithTimeout(ctx, b.RpcTimeout)
+	cCtx, cancel := context.WithTimeout(ctx, b.RPCTimeout)
 	defer cancel()
 	return b.c.CallContext(cCtx, result, method, args...)
 }
 
 func (b *BaseRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
-	cCtx, cancel := context.WithTimeout(ctx, b.RpcBatchTimeout)
+	cCtx, cancel := context.WithTimeout(ctx, b.RPCBatchTimeout)
 	defer cancel()
 	return b.c.BatchCallContext(cCtx, batch)
 }

--- a/op-service/client/rpc.go
+++ b/op-service/client/rpc.go
@@ -105,12 +105,12 @@ func NewRPC(ctx context.Context, lgr log.Logger, addr string, opts ...RPCOption)
 		return nil, err
 	}
 
-	baseRPCClient := &BaseRPCClient{c: underlying, rpcTimeout: defaultRpcTimeout, rpcBatchTimeout: defaultRpcBatchTimeout}
+	baseRPCClient := &BaseRPCClient{c: underlying, RpcTimeout: defaultRpcTimeout, RpcBatchTimeout: defaultRpcBatchTimeout}
 	if cfg.rpcTimeout != nil {
-		baseRPCClient.rpcTimeout = *cfg.rpcTimeout
+		baseRPCClient.RpcTimeout = *cfg.rpcTimeout
 	}
 	if cfg.rpcBatchTimeout != nil {
-		baseRPCClient.rpcBatchTimeout = *cfg.rpcBatchTimeout
+		baseRPCClient.RpcBatchTimeout = *cfg.rpcBatchTimeout
 	}
 	var wrapped RPC = baseRPCClient
 
@@ -175,12 +175,17 @@ func IsURLAvailable(address string) bool {
 // It sets a timeout of 10s on CallContext & 20s on BatchCallContext made through it.
 type BaseRPCClient struct {
 	c               *rpc.Client
-	rpcTimeout      time.Duration
-	rpcBatchTimeout time.Duration
+	RpcTimeout      time.Duration
+	RpcBatchTimeout time.Duration
+}
+
+type BaseRpcTimeout struct {
+	RpcTimeout      time.Duration
+	RpcBatchTimeout time.Duration
 }
 
 func NewBaseRPCClient(c *rpc.Client) *BaseRPCClient {
-	return &BaseRPCClient{c: c, rpcTimeout: defaultRpcTimeout, rpcBatchTimeout: defaultRpcBatchTimeout}
+	return &BaseRPCClient{c: c, RpcTimeout: defaultRpcTimeout, RpcBatchTimeout: defaultRpcBatchTimeout}
 }
 
 func (b *BaseRPCClient) Close() {
@@ -188,13 +193,13 @@ func (b *BaseRPCClient) Close() {
 }
 
 func (b *BaseRPCClient) CallContext(ctx context.Context, result any, method string, args ...any) error {
-	cCtx, cancel := context.WithTimeout(ctx, b.rpcTimeout)
+	cCtx, cancel := context.WithTimeout(ctx, b.RpcTimeout)
 	defer cancel()
 	return b.c.CallContext(cCtx, result, method, args...)
 }
 
 func (b *BaseRPCClient) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
-	cCtx, cancel := context.WithTimeout(ctx, b.rpcBatchTimeout)
+	cCtx, cancel := context.WithTimeout(ctx, b.RpcBatchTimeout)
 	defer cancel()
 	return b.c.BatchCallContext(cCtx, batch)
 }

--- a/op-service/dial/dial.go
+++ b/op-service/dial/dial.go
@@ -35,7 +35,7 @@ func DialEthClientWithTimeout(ctx context.Context, timeout time.Duration, log lo
 
 // DialRollupClientWithTimeout attempts to dial the RPC provider using the provided URL.
 // If the dial and rpc calls don't complete within timeout seconds, this method will return an error.
-func DialRollupClientWithTimeout(ctx context.Context, timeout time.Duration, log log.Logger, url string, rpcTimeoutCfg ...client.BaseRpcTimeout) (*sources.RollupClient, error) {
+func DialRollupClientWithTimeout(ctx context.Context, timeout time.Duration, log log.Logger, url string, rpcTimeoutCfg ...client.BaseRPCTimeout) (*sources.RollupClient, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -49,11 +49,11 @@ func DialRollupClientWithTimeout(ctx context.Context, timeout time.Duration, log
 		if len(rpcTimeoutCfg) > 1 {
 			return nil, fmt.Errorf("too many rpc timeout configs provided")
 		}
-		if rpcTimeoutCfg[0].RpcTimeout != 0 {
-			baseRPCClient.RpcTimeout = rpcTimeoutCfg[0].RpcTimeout
+		if rpcTimeoutCfg[0].RPCTimeout != 0 {
+			baseRPCClient.RPCTimeout = rpcTimeoutCfg[0].RPCTimeout
 		}
-		if rpcTimeoutCfg[0].RpcBatchTimeout != 0 {
-			baseRPCClient.RpcBatchTimeout = rpcTimeoutCfg[0].RpcBatchTimeout
+		if rpcTimeoutCfg[0].RPCBatchTimeout != 0 {
+			baseRPCClient.RPCBatchTimeout = rpcTimeoutCfg[0].RPCBatchTimeout
 		}
 	}
 	return sources.NewRollupClient(baseRPCClient), nil


### PR DESCRIPTION
The `rollup client` wraps the `BaseRPC` structure using the default timeout. This PR allows us to modify the default timeout by minimizing the changes.