### PR TITLE
Check for Shanghai in test node rather than Canyon

### DIFF
--- a/op-e2e/op_geth.go
+++ b/op-e2e/op_geth.go
@@ -215,7 +215,7 @@ func (d *OpGeth) CreatePayloadAttributes(txs ...*types.Transaction) (*eth.Payloa
 	}
 
 	var withdrawals *types.Withdrawals
-	if d.L2ChainConfig.IsCanyon(uint64(timestamp)) {
+	if d.L2ChainConfig.IsShanghai(new(big.Int).SetUint64(uint64(d.L2Head.BlockNumber)), uint64(timestamp)) {
 		withdrawals = &types.Withdrawals{}
 	}
 


### PR DESCRIPTION
The test op-geth code adds withdrawals only if Canyon has been enabled. This worked upstream because Shanghai and Canyon were enabled concurrently, but it's not actually the right behavior.