### PR TITLE
Re-enable disabled op-e2e tests

### DIFF
--- a/op-e2e/external_erigon/main.go
+++ b/op-e2e/external_erigon/main.go
@@ -165,6 +165,12 @@ func execute(binPath string, config external.Config) (*erigonSession, error) {
 		return nil, fmt.Errorf("started did not finish in time")
 	}
 
+	// TODO(jky) this is a horrible hack, but giving Erigon just a little extra
+	// time to stabilize seems to drastically improve the reliability of these
+	// tests in CI, ideally we should add in a log message we can scrape once the
+	// system is 'really' up, but there's not one that's readily apparent.
+	time.Sleep(5 * time.Second)
+
 	return &erigonSession{
 		session: sess,
 		endpoints: &external.Endpoints{

--- a/op-e2e/external_erigon/test_parms.json
+++ b/op-e2e/external_erigon/test_parms.json
@@ -19,11 +19,6 @@
     "TestCannonPoisonedPostState": "TODO, this should be investigated, is probably the debug_dbGet though",
     "TestPreregolith/UnusedGasConsumed_RegolithNotScheduled": "Erigon doesn't reject building the block when the gas exceeds the block gas limit; instead, it discards transactions until they fit within the block",
     "TestPreregolith/UnusedGasConsumed_RegolithNotYetActive": "Erigon doesn't reject building the block when the gas exceeds the block gas limit; instead, it discards transactions until they fit within the block",
-    "TestMultipleGameTypes": "TODO, this should be investigated, is probably the debug_dbGet though",
-    "TestSystemE2EDencunAtGenesisWithBlobs": "TODO, this should be investigated, but likely is because our Erigon is out of date",
-    "TestEcotone": "TODO, this should be investigated, but likely is because our Erigon is out of date",
-    "TestSystem4844E2E": "TODO, this should be investigated, but likely is because our Erigon is out of date",
-    "TestFees/ecotone": "TODO, this should be investigated, but likely is because our Erigon is out of date",
-    "TestSequencerFailover_SetupCluster": "TODO, this should be investigated, but likely is because our Erigon is out of date"
+    "TestMultipleGameTypes": "TODO, this should be investigated, is probably the debug_dbGet though"
   }
 }

--- a/op-e2e/op_geth.go
+++ b/op-e2e/op_geth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
@@ -82,8 +83,9 @@ func NewOpGeth(t *testing.T, ctx context.Context, cfg *SystemConfig) (*OpGeth, e
 		require.Nil(t, gethNode.Start())
 		node = gethNode
 	} else {
+		safeName := strings.ReplaceAll(t.Name(), "/", "_")
 		externalNode := (&ExternalRunner{
-			Name:     "l2",
+			Name:     fmt.Sprintf("%s-l2", safeName),
 			BinPath:  cfg.ExternalL2Shim,
 			Genesis:  l2Genesis,
 			JWTPath:  cfg.JWTFilePath,


### PR DESCRIPTION
~Updates e2e tests to point to **https://github.com/bobanetwork/v3-erigon/pull/83**~

Meant to merge this earlier, but we've since updated the op-erigon version.  This PR now only re-enables those tests.