### PR TITLE
Update token-bridging doc

### DIFF
--- a/.gitbook/contents/developer/boba-basics/bridge-basics/boba-token-bridge.md
+++ b/.gitbook/contents/developer/boba-basics/bridge-basics/boba-token-bridge.md
@@ -8,15 +8,11 @@ The BOBA token bridge functionality provides a method for the BOBA token to be d
 
 The BOBA Token Bridge is composed of two main contracts the [`EthBridge` (opens new window)](https://github.com/bobanetwork/boba\_legacy/blob/develop/packages/boba/contracts/contracts/lzTokenBridge/EthBridge.sol)(for Ethereum) and the [`AltL1Bridge` (opens new window)](https://github.com/bobanetwork/boba/blob/develop/packages/boba\_legacy/contracts/contracts/lzTokenBridge/AltL1Bridge.sol)(for Alt L1s).
 
-> Note: **To protect our users, we are only allowed to bridge BOBA tokens between Ethereum and Alt L1s.** For example, you are not allowed to directly bridge BOBA tokens from Moonbeam to BNB. What you can do is to bridge it from Moonbeam to Etherem and bridge it to BNB.
-
 Here we'll go over the basics of using this bridge to move BOBA tokens between Layer 1s.
 
 <figure><img src="../../../../assets/bridge boba tokens from ethereum.png" alt=""><figcaption></figcaption></figure>
 
-For normal users, you can go to [Ethereum Gateway](https://gateway.boba.network) first, then head to [wallet](https://gateway.boba.network/wallet) page. After connecting to it on Ethereum, you can click the `Bridge To Alt L1` button to bridge your BOBA tokens from Ethereum to Alt L1s.
-
-> Video: https://twitter.com/i/status/1598360155825278977
+For normal users, bridging can be accomplished simply via the [Light Bridge](contents/developer/boba-basics/bridge-basics/light-bridge.md).
 
 For developers, you can interact with [`EthBridge` (opens new window)](https://github.com/bobanetwork/boba\_legacy/blob/develop/packages/boba/contracts/contracts/lzTokenBridge/EthBridge.sol) to deposit BOBA tokens from Ethereum to Alt L1s.
 
@@ -87,7 +83,7 @@ Example code can be found here: [bridgeFromEthereumToAltL.js](https://github.com
 
 <figure><img src="../../../../assets/bridge boba tokens from alt l1s.png" alt=""><figcaption></figcaption></figure>
 
-For normal users, you can go to [Alt L1 Gateway](https://gateway.boba.network) first, then head to [wallet](https://gateway.boba.network/wallet/) page. After connecting to it on Alt L1, you can click the `Bridge To Ethereum` button to bridge your BOBA tokens from Alt L1 to Ethereum.
+For normal users, bridging can be accomplished simply via the [Light Bridge](contents/developer/boba-basics/bridge-basics/light-bridge.md).
 
 For developers, you can interact with [`AltL1Bridge` (opens new window)](https://github.com/bobanetwork/boba\_legacy/blob/develop/packages/boba/contracts/contracts/lzTokenBridge/AltL1Bridge.sol) to deposit BOBA tokens from Alt L1 to Ethereum.
 
@@ -170,9 +166,6 @@ console.log(`-> Sent ${DEPOSIT_AMOUNT} BOBA tokens to the bridge contract....`);
 | Contract Name                 | Contract Address                           |
 | ----------------------------- | ------------------------------------------ |
 | Proxy\_\_EthBridgeToBNB       | 0x1A36E24D61BC1aDa68C21C2Da1aD53EaB8E03e55 |
-| Proxy\_\_EthBridgeToFantom    | 0x9DD4202AA5ee9625d1eaa671E2294014dd434E7E |
-| Proxy\_\_EthBridgeToAvalanche | 0xB0003eB166654f7e57c0463F8D1a438eB238c490 |
-| Proxy\_\_EthBridgeToMoonbeam  | 0x6F537839714761388B6d7ED61Bc09579d5dA2F41 |
 | L1\_BOBA                      | 0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc |
 
 #### BNB Contract


### PR DESCRIPTION
The UI component for the L1<->L1 alt bridging has been removed, so removed this from the documentation.  Additionally, as Boba no longer integrates with Avalanche, Fantom, or Moonbeam, removing these contracts from the list.