### PR TITLE
Add HC tutorial placeholder

### DIFF
--- a/.gitbook/SUMMARY.md
+++ b/.gitbook/SUMMARY.md
@@ -7,7 +7,7 @@
   * [Fraud Detection](https://github.com/bobanetwork/boba\_legacy/blob/develop/boba\_community/fraud-detector/README.md)
   * [NFTs](contents/user/003\_nfts.md)
 * [Welcome to Hybrid Compute](contents/developer/hybrid\_compute.md)
-  * [Hybrid Compute 101](https://github.com/bobanetwork/HybridCompute\_Tutorial/blob/non-local-starter/README.md)
+  * [Hybrid Compute 101](contents/hc/tutorial.md) 
   * [Implementation](contents/hc/implementation.md)
   * [Wizard](contents/hc/start.md)
   * [Examples](contents/hc/examples/README.md)

--- a/.gitbook/contents/hc/tutorial.md
+++ b/.gitbook/contents/hc/tutorial.md
@@ -1,0 +1,7 @@
+---
+description: HybridCompute Compute 101 - Tutorial
+---
+
+<figure><img src="../../assets/hc-under-upgrade.png" alt=""><figcaption></figcaption></figure>
+
+This page is a placeholder, while the new documentation is being created. You can still access the [existing but outdated tutorial](https://github.com/bobanetwork/HybridCompute\_Tutorial/blob/non-local-starter/README.md).


### PR DESCRIPTION
The existing HC tutorial document exists in the legacy repo.  Rather than adding a banner or other notice of deprecation (which is rather implicit by being in the legacy repo), this PR creates a placeholder file in the new repo and marks it as a WIP.