### PR TITLE
Fix semgrep

### DIFF
--- a/.semgrep/sol-rules.yaml
+++ b/.semgrep/sol-rules.yaml
@@ -38,6 +38,10 @@ rules:
         - packages/contracts-bedrock/src/L2/SuperchainWETH.sol
         - packages/contracts-bedrock/src/governance/interfaces/IGovernanceToken.sol
         - packages/contracts-bedrock/src/governance/GovernanceToken.sol
+        - packages/contracts-bedrock/lib
+        - packages/contracts-bedrock/src/boba/WETH9.sol
+        - packages/contracts-bedrock/src/boba/BOBA.sol
+        - packages/contracts-bedrock/src/boba/L2GovernanceERC20.sol
 
   - id: sol-style-return-arg-fmt
     languages: [solidity]
@@ -52,6 +56,10 @@ rules:
         - packages/contracts-bedrock/scripts/interfaces/IGnosisSafe.sol
         - packages/contracts-bedrock/src/dispute/interfaces/IPermissionedDisputeGame.sol
         - packages/contracts-bedrock/src/dispute/interfaces/IFaultDisputeGame.sol
+        - packages/contracts-bedrock/lib
+        - packages/contracts-bedrock/src/boba/WETH9.sol
+        - packages/contracts-bedrock/src/boba/BOBA.sol
+        - packages/contracts-bedrock/src/boba/L2GovernanceERC20.sol
 
   - id: sol-style-doc-comment
     languages: [solidity]
@@ -61,6 +69,10 @@ rules:
     paths:
       exclude:
         - packages/contracts-bedrock/test/safe-tools/CompatibilityFallbackHandler_1_3_0.sol
+        - packages/contracts-bedrock/lib
+        - packages/contracts-bedrock/src/boba/WETH9.sol
+        - packages/contracts-bedrock/src/boba/BOBA.sol
+        - packages/contracts-bedrock/src/boba/L2GovernanceERC20.sol
 
   - id: sol-expectrevert-no-args
     languages: [solidity]
@@ -71,6 +83,10 @@ rules:
     paths:
       exclude:
         - packages/contracts-bedrock/test
+        - packages/contracts-bedrock/lib
+        - packages/contracts-bedrock/src/boba/WETH9.sol
+        - packages/contracts-bedrock/src/boba/BOBA.sol
+        - packages/contracts-bedrock/src/boba/L2GovernanceERC20.sol
 
   - id: sol-style-malformed-require
     languages: [solidity]
@@ -93,6 +109,10 @@ rules:
         - packages/contracts-bedrock/src/cannon/MIPS2.sol
         - packages/contracts-bedrock/src/cannon/libraries/MIPSMemory.sol
         - packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+        - packages/contracts-bedrock/lib
+        - packages/contracts-bedrock/src/boba/WETH9.sol
+        - packages/contracts-bedrock/src/boba/BOBA.sol
+        - packages/contracts-bedrock/src/boba/L2GovernanceERC20.sol
 
   - id: sol-style-malformed-revert
     languages: [solidity]
@@ -107,3 +127,7 @@ rules:
       exclude:
         - packages/contracts-bedrock/test
         - packages/contracts-bedrock/src/cannon/libraries/MIPSInstructions.sol
+        - packages/contracts-bedrock/lib
+        - packages/contracts-bedrock/src/boba/WETH9.sol
+        - packages/contracts-bedrock/src/boba/BOBA.sol
+        - packages/contracts-bedrock/src/boba/L2GovernanceERC20.sol


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

The fix is tested.

```
~/Documents/GitHub/boba.nosync enable-TestRequiredProtocolVersionChangeAndHalt* ❯ just semgrep                                                                                                                                                                                                    02:54:36 PM
semgrep scan --config=.semgrep --error .

┌──── ○○○ ────┐
│ Semgrep CLI │
└─────────────┘

                                                                                                                        
Scanning 3801 files (only git-tracked) with 8 Code rules:
            
  CODE RULES
  Scanning 670 files with 8 solidity rules.
                    
  SUPPLY CHAIN RULES
                  
  No rules to run.
                  
          
  PROGRESS
   
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00                                                                                                                        
                
                
┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.
  Partially scanned: 10 files only partially analyzed due to parsing or internal Semgrep errors
  Scan skipped: 23 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 8 rules on 670 files: 0 findings.

✨ If Semgrep missed a finding, please send us feedback to let us know!
   See https://semgrep.dev/docs/reporting-false-negatives/
```
