### PR TITLE
Defined the logo for sharing URLs on mobile

### DIFF
--- a/boba-docs/docusaurus.config.js
+++ b/boba-docs/docusaurus.config.js
@@ -13,11 +13,7 @@ const config = {
   favicon: 'img/boba_B.ico',
 
   // Set the production url of your site here
-<<<<<<< Updated upstream
-  url: 'https://docs.boba.network',
-=======
   url: 'https://docs.boba.network/',
->>>>>>> Stashed changes
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',

--- a/boba-docs/docusaurus.config.js
+++ b/boba-docs/docusaurus.config.js
@@ -13,18 +13,32 @@ const config = {
   favicon: 'img/boba_B.ico',
 
   // Set the production url of your site here
+<<<<<<< Updated upstream
   url: 'https://docs.boba.network',
+=======
+  url: 'https://docs.boba.network/',
+>>>>>>> Stashed changes
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  // organizationName: 'facebook', // Usually your GitHub org/user name.
+  // projectName: 'docusaurus', // Usually your repo name.
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
+
+  headTags: [
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'icon',
+        href: '/img/boba_B.ico',
+      },
+    },
+  ],
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/boba-docs/src/theme/SearchBar.js
+++ b/boba-docs/src/theme/SearchBar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import SearchBar from '@theme-original/SearchBar';
-import AskCookbook from '@cookbookdev/docsbot/react'
+// import AskCookbook from '@cookbookdev/docsbot/react'
 import BrowserOnly from '@docusaurus/BrowserOnly';
 /** It's a public API key, so it's safe to expose it here */
 const COOKBOOK_PUBLIC_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NzExNmE2MTk1MmE0NWM4NTM5NDQzMjIiLCJpYXQiOjE3MjkxOTQ1OTMsImV4cCI6MjA0NDc3MDU5M30.xFCIzHrJLoK58twx7xclnKUVZNGwVClVWpPypG43NEc";
@@ -8,7 +8,7 @@ export default function SearchBarWrapper(props) {
   return (
     <>
       <SearchBar {...props} />
-      <BrowserOnly>{() => <AskCookbook apiKey={COOKBOOK_PUBLIC_API_KEY} /> }</BrowserOnly>
+      {/* <BrowserOnly>{() => <AskCookbook apiKey={COOKBOOK_PUBLIC_API_KEY} /> }</BrowserOnly> */}
     </>
   );
 }


### PR DESCRIPTION
:clipboard: [Add associated issues, tickets, docs URL here.](https://enyainc.slack.com/archives/C08KX6V70HL/p1743449262909589)

## Overview

When sharing boba docs on mobile, the link preview logo defaults to the docusaurus one instead of ours.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Introduced some head tags to the docusaurus config

## Testing

Describe how to test your new feature/bug fix and if possible, a step by step guide on how to demo this.
