### PR TITLE
Fix `fs` arbitrary file access during archive extraction zipslip 

### DIFF
--- a/devnet-sdk/kt/fs/fs.go
+++ b/devnet-sdk/kt/fs/fs.go
@@ -109,11 +109,22 @@ func (a *Artifact) Download(path string) error {
 		}
 
 		fpath := filepath.Join(path, filepath.Clean(header.Name))
+		absPath, err := filepath.Abs(fpath)
+		if err != nil {
+			return fmt.Errorf("failed to compute absolute path for %s: %w", fpath, err)
+		}
+		absBasePath, err := filepath.Abs(path)
+		if err != nil {
+			return fmt.Errorf("failed to compute absolute base path for %s: %w", path, err)
+		}
+		if !strings.HasPrefix(absPath, absBasePath) {
+			return fmt.Errorf("path traversal detected: %s is outside of %s", absPath, absBasePath)
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(fpath, os.FileMode(header.Mode)); err != nil {
-				return fmt.Errorf("failed to create directory %s: %w", fpath, err)
+			if err := os.MkdirAll(absPath, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", absPath, err)
 			}
 		case tar.TypeReg:
 			// Create parent directories if they don't exist


### PR DESCRIPTION
https://github.com/bobanetwork/boba/blob/35dc7928226a7e43d5f7b799e161275e431a6fd6/devnet-sdk/kt/fs/fs.go#L103-L116

Fix the issue need to validate the constructed file paths to ensure they remain within the intended extraction directory (`path`). This can be achieved by comparing the absolute path of the constructed file (`fpath`) with the absolute path of the extraction directory (`path`). If the constructed file path is not a descendant of the extraction directory, it should be rejected.

Steps to implement the fix:
1. Compute the absolute path of the extraction directory (`path`) using `filepath.Abs`.
2. Compute the absolute path of the constructed file (`fpath`) using `filepath.Abs`.
3. Check if the constructed file path starts with the extraction directory path. If not, return an error or skip the file.
4. Apply this validation before performing any file system operations.

