### PR TITLE
fix: typos in files

### DIFF
--- a/boba-docs/docs/0_index.md
+++ b/boba-docs/docs/0_index.md
@@ -17,6 +17,6 @@ Learn more about Boba through the following documentation:
 - [Indexers](./indexers/subgraph) discusses how to integrate with supported data indexers.
 - [Fees](./fees/fee-scheme) discusses the fees and custom fee tokens involved with Boba.
 - [Contract and Token Addresses](./addresses/index) lists all boba-related contract and token addresses.
-- [Testnet Faucets](./faucets) lists the faucets availabe for use on Sepolia and Boba networks.
+- [Testnet Faucets](./faucets) lists the faucets available for use on Sepolia and Boba networks.
 - [Notices](./notices/holocene-breaking-changes) lists any breaking changes or other noteworthy events taking place on the network.
 - [FAQ](./faq) has the answers to Boba's frequently asked questions.

--- a/boba-docs/docs/account-abstraction/2_bundler-api.md
+++ b/boba-docs/docs/account-abstraction/2_bundler-api.md
@@ -41,7 +41,7 @@ Otherwise it returns an error object with `code` and `message`. (and sometimes `
 | -32504   | Transaction rejected because paymaster (or signature aggregator) is throttled/banned                                                |
 | -32505   | Transaction rejected because paymaster (or signature aggregator) stake or unstake-delay is too low                                  |
 | -32506   | Transaction rejected because wallet specified unsupported signature aggregator                                                      |
-| -32507   | Transaction rejected because of wallet signature check failed (or paymaster siganture, if the paymaster uses its data as signature) |
+| -32507   | Transaction rejected because of wallet signature check failed (or paymaster signature, if the paymaster uses its data as signature) |
 | -32508   | UserOperation not in valid time-range: either wallet or paymaster returned a time-range, and it is valid in the future              |
 
 #### Usage

--- a/boba-docs/docs/node-operators/1_run-node-docker.md
+++ b/boba-docs/docs/node-operators/1_run-node-docker.md
@@ -139,7 +139,7 @@ docker-compose -f docker-compose-mainnet-geth.yml up -d
 docker-compose -f [docker-compose-file] up -d
 ```
 
-Will start the node in a detatched shell (`-d`), meaning the node will continue to run in the background.
+Will start the node in a detached shell (`-d`), meaning the node will continue to run in the background.
 
 ### View Logs
 

--- a/kurtosis-devnet/README.md
+++ b/kurtosis-devnet/README.md
@@ -103,7 +103,7 @@ interop-devnet: (devnet "interop.yaml")
 ## devnet output
 
 One important aspect of the devnet workflow is that the output should be
-*consumable*. Going forward we want to integrate them into larger worfklows
+*consumable*. Going forward we want to integrate them into larger workflows
 (serving as targets for tests for example, or any other form of automation).
 
 To address this, the deployment tool outputs a document with (hopefully!) useful


### PR DESCRIPTION
Corrected "availabe" → "available"
Corrected "siganture" → "signature"
Corrected "detatched" → "detached"
Corrected "worfklows" → "workflows"