### PR TITLE
fix: correct spelling of "CanonicalHash" in comment

### DIFF
--- a/op-supervisor/supervisor/backend/db/logs/state.go
+++ b/op-supervisor/supervisor/backend/db/logs/state.go
@@ -244,7 +244,7 @@ func (l *logContext) appendEntry(obj EntryObj) {
 }
 
 // infer advances the logContext in cases where complex entries contain multiple implied entries
-// eg. a SearchCheckpoint implies a CannonicalHash will follow
+// eg. a SearchCheckpoint implies a CanonicalHash will follow
 // this also handles inserting the searchCheckpoint at the set frequency, and padding entries
 func (l *logContext) infer() error {
 	// We force-insert a checkpoint whenever we hit the known fixed interval.


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

Fixed typo in comment where "CannonicalHash" was incorrectly spelled with double 'n'. The correct spelling is "CanonicalHash" with single 'n'.
This is a documentation-only change with no functional impact.
