### PR TITLE
Updates the Fusaka notice with the newly released versions.

### DIFF
--- a/boba-community/docker-compose-boba-mainnet-geth.yml
+++ b/boba-community/docker-compose-boba-mainnet-geth.yml
@@ -12,7 +12,7 @@ version: '3.4'
 
 services:
   l2:
-    image: us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-geth:${GETH_VERSION:-v1.101411.0}
+    image: us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-geth:${GETH_VERSION:-v1.101603.5}
     command: >
       --datadir=/db
       --networkid=288
@@ -42,7 +42,7 @@ services:
   op-node:
     depends_on:
       - l2
-    image: us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-node:${OP_NODE_VERSION:-latest}
+    image: us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-node:${OP_NODE_VERSION:-v1.16.2}
     command: >
       op-node
       --l1=${ETH1_HTTP:-https://mainnet.gateway.tenderly.co}

--- a/boba-community/docker-compose-boba-sepolia-geth.yml
+++ b/boba-community/docker-compose-boba-sepolia-geth.yml
@@ -12,7 +12,7 @@ version: '3.4'
 
 services:
   l2:
-    image: us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-geth:${GETH_VERSION:-v1.101411.0}
+    image: us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-geth:${GETH_VERSION:-v1.101603.5}
     command: >
       --datadir=/db
       --networkid=28882
@@ -43,7 +43,7 @@ services:
   op-node:
     depends_on:
       - l2
-    image: us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-node:${OP_NODE_VERSION:-latest}
+    image: us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-node:${OP_NODE_VERSION:-v1.16.2}
     command: >
       op-node
       --l1=${ETH1_HTTP:-https://sepolia.gateway.tenderly.co}

--- a/boba-docs/docs/notices/90_fusaka-breaking-changes.md
+++ b/boba-docs/docs/notices/90_fusaka-breaking-changes.md
@@ -4,14 +4,16 @@ The Fusaka upgrade on Ethereum is currently scheduled and requires mandatory upg
 
 * Holesky activation: October 1st
 * Sepolia activation: October 14th
-* Mainnet activation: October 28th
+* Mainnet activation: December 3rd
 
 ## For Node Operators
 
 Node operators will need to upgrade to the respective releases before the activation dates. These following steps are necessary for every node operator:
 
-* op-node at [v1.14.1](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.14.1)
-* op-geth at [v1.101603.1](https://github.com/bobanetwork/op-geth/releases/tag/v1.101603.1)
+*Update:*  There is a recommended upgrade for the op-node and op-geth components.  The previously specified versions from this notice should still be Fusaka compatible, but, newer versions are recommended.
+
+* op-node at [v1.16.2](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.2-boba) (formnerly at [v1.14.1](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.14.1))
+* op-geth at [v1.101603.5](https://github.com/bobanetwork/op-geth/releases/tag/v1.101603.5) (formerly at [v1.101603.1](https://github.com/bobanetwork/op-geth/releases/tag/v1.101603.1))
 * op-erigon currently does not have Fusaka support, operators are advised to migrate to op-geth
 
 :::note


### PR DESCRIPTION
Although these newly released versions should not be strictly required for Fusaka compatibility, the upstream recommends moving to these versions, so we shall too.