### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/boba-docs/dev-docs/71_faucets.md
+++ b/boba-docs/dev-docs/71_faucets.md
@@ -6,14 +6,15 @@ description: Testnet faucets
 
 Faucets are tools for developers that give you free ETH (and other tokens) on test networks like Sepolia and Boba Sepolia. This lets you send transactions and make smart contracts for testing. Below, you'll see a list of working faucets to use. Each faucet might ask you to prove who you are in different ways, so you might need to try a few to find one that works. Sometimes, faucets might run out of ETH. If you can't get ETH from one, just try another.
 
-| Faucet Name                                                         | Supported Networks    |
-|---------------------------------------------------------------------|-----------------------|
-| [L2Faucet](https://www.l2faucet.com/)                               | Sepolia, Boba Sepolia |
-| [Alchemy Faucet](https://www.alchemy.com/faucets/ethereum-sepolia)  | Sepolia               |
-| [Infura Faucet](https://www.infura.io/faucet/sepolia)               | Sepolia               |
-| [QuickNode Faucet](https://faucet.quicknode.com/drip)               | Sepolia               |
-| [PoW Faucet](https://sepolia-faucet.pk910.de/)                      | Sepolia               |
-| [Boba ETH Testnet Faucet](https://faucet.sepolia.boba.network/)     | Boba ETH Testnet      |
+| Faucet Name                                                                 | Supported Networks    |
+|-----------------------------------------------------------------------------|-----------------------|
+| [L2Faucet](https://www.l2faucet.com/)                                       | Sepolia, Boba Sepolia |
+| [Alchemy Faucet](https://www.alchemy.com/faucets/ethereum-sepolia)          | Sepolia               |
+| [Infura Faucet](https://www.infura.io/faucet/sepolia)                       | Sepolia               |
+| [QuickNode Faucet](https://faucet.quicknode.com/drip)                       | Sepolia               |
+| [PoW Faucet](https://sepolia-faucet.pk910.de/)                              | Sepolia               |
+| [Boba ETH Testnet Faucet](https://faucet.sepolia.boba.network/)             | Boba ETH Testnet      |
+| [EthFaucet.com](https://ethfaucet.com?utm_source=boba_docs&utm_medium=docs) | Sepolia, Boba Sepolia |
 
 ## Bridge from Sepolia
 


### PR DESCRIPTION
## Overview

Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with 0.1 Boba Sepolia ETH for free, claimable once every 24 hours.

Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.

## Changes

Added a new line to the "Faucets" table in docs.
