### PR TITLE
test: remove duplicate require.NoError calls

### DIFF
--- a/op-node/rollup/derive/attributes_test.go
+++ b/op-node/rollup/derive/attributes_test.go
@@ -237,7 +237,6 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		epoch := l1Info.ID()
 		l1InfoTx, err := L1InfoDepositBytes(cfg, params.MergedTestChainConfig, testSysCfg, seqNumber, l1Info, 0)
 		require.NoError(t, err)
-		require.NoError(t, err)
 
 		var l2Txs []eth.Data
 		l2Txs = append(l2Txs, l1InfoTx)
@@ -277,7 +276,6 @@ func TestPreparePayloadAttributes(t *testing.T) {
 		seqNumber := l2Parent.SequenceNumber + 1
 		epoch := l1Info.ID()
 		l1InfoTx, err := L1InfoDepositBytes(cfg, params.MergedTestChainConfig, testSysCfg, seqNumber, l1Info, 0)
-		require.NoError(t, err)
 		require.NoError(t, err)
 
 		var l2Txs []eth.Data


### PR DESCRIPTION
Removed duplicate `require.NoError(t, err)` calls in two test cases. The same error variable was being checked twice in a row which doesn't make sense - if the first check passes, the second one will always pass too. Looks like a copy-paste mistake when these similar test functions were created.