### PR TITLE
op-node/v1.16.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 #
 
 SHELL := /usr/bin/env bash
-.PHONY: all build test clean submodule-update help patch-apply patch-restore
+.PHONY: all build test clean submodule-update help patch-apply patch-restore docker-build
 
 # Directories
 REPO_ROOT := $(shell pwd)
@@ -24,6 +24,9 @@ BUILD_DIR := $(REPO_ROOT)/.boba-build
 UPSTREAM_TARGETS := op-node op-batcher op-proposer op-challenger op-program \
                     op-dispute-mon op-conductor op-supervisor op-wheel \
                     op-deployer op-faucet cannon
+
+# Docker container components to build
+DOCKER_TARGETS := op-node op-batcher op-proposer op-challenger op-dispute-mon op-supervisor op-conductor
 
 # Default target
 all: build
@@ -39,6 +42,7 @@ help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  build              - Build all Go binaries (with Boba patches)"
+	@echo "  docker-build       - Build all Docker containers"
 	@echo "  test               - Run tests"
 	@echo "  clean              - Clean build artifacts and restore patches"
 	@echo "  submodule-update   - Update upstream submodule to latest"
@@ -48,9 +52,13 @@ help:
 	@echo "Individual component targets:"
 	@echo "  $(UPSTREAM_TARGETS)"
 	@echo ""
+	@echo "Docker targets:"
+	@echo "  $(DOCKER_TARGETS)"
+	@echo ""
 	@echo "Environment variables:"
 	@echo "  BOBA_KEEP_PATCHES=1  - Don't restore patches after build"
-	@echo "  BOBA_DRY_RUN=1       - Prepare but don't build"
+	@echo "  PLATFORM=linux/arm64 - Target platform for docker-build"
+	@echo "  TARGETS=\"op-node\"    - Specific targets for docker-build"
 	@echo ""
 
 # Apply patches to submodule
@@ -184,3 +192,41 @@ endif
 	cd $(SUBMODULE) && git fetch origin && git checkout $(REF)
 	git add $(SUBMODULE)
 	@echo "Submodule pinned to $(REF). Review changes and commit when ready."
+
+# Build all Docker containers
+# Usage: make docker-build
+#        make docker-build PLATFORM=linux/arm64
+#        make docker-build TARGETS="op-node op-batcher"
+docker-build: patch-apply
+	@echo "Building Docker containers..."
+	@# Setup buildx builder if needed
+	@docker buildx inspect buildx-build >/dev/null 2>&1 || \
+		docker buildx create --driver=docker-container --name=buildx-build --bootstrap --use
+	@# Set build variables
+	$(eval GIT_COMMIT := $(shell git rev-parse HEAD))
+	$(eval GIT_DATE := $(shell git show -s --format='%ct'))
+	$(eval GIT_VERSION := $(shell git describe --tags --always 2>/dev/null || echo "dev"))
+	$(eval PLATFORM := $(or $(PLATFORM),linux/amd64))
+	$(eval TARGETS := $(or $(TARGETS),$(DOCKER_TARGETS)))
+	$(eval KONA_VERSION := $(shell jq -r .version $(SUBMODULE)/kona/version.json))
+	@echo "Building targets: $(TARGETS)"
+	@echo "Platform: $(PLATFORM)"
+	@echo "Git commit: $(GIT_COMMIT)"
+	@echo "Git version: $(GIT_VERSION)"
+	@# Run docker buildx bake
+	cd $(SUBMODULE) && \
+		GIT_COMMIT=$(GIT_COMMIT) \
+		GIT_DATE=$(GIT_DATE) \
+		GIT_VERSION=$(GIT_VERSION) \
+		PLATFORMS=$(PLATFORM) \
+		KONA_VERSION=$(KONA_VERSION) \
+		docker buildx bake \
+			--progress plain \
+			--builder=buildx-build \
+			--load \
+			-f docker-bake.hcl \
+			$(TARGETS)
+	@if [ "$(BOBA_KEEP_PATCHES)" != "1" ]; then \
+		$(MAKE) patch-restore; \
+	fi
+	@echo "Docker build complete."

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ help:
 	@echo ""
 	@echo "Environment variables:"
 	@echo "  BOBA_KEEP_PATCHES=1  - Don't restore patches after build"
-	@echo "  PLATFORM=linux/arm64 - Target platform for docker-build"
+	@echo "  TAG=v1.16.5          - Image tag for docker-build (default: git commit)"
 	@echo "  TARGETS=\"op-node\"    - Specific targets for docker-build"
 	@echo ""
 
@@ -197,40 +197,41 @@ endif
 	git add $(SUBMODULE)
 	@echo "Submodule pinned to $(REF). Review changes and commit when ready."
 
-# Build all Docker containers
+# Build all Docker containers using podman
 # Usage: make docker-build
-#        make docker-build PLATFORM=linux/arm64
 #        make docker-build TARGETS="op-node op-batcher"
+#        make docker-build TAG=v1.16.5
 docker-build: patch-apply
-	@echo "Building Docker containers..."
-	@# Setup buildx builder if needed
-	@docker buildx inspect buildx-build >/dev/null 2>&1 || \
-		docker buildx create --driver=docker-container --name=buildx-build --bootstrap --use
-	@# Set build variables
+	@echo "Building Docker containers with podman..."
 	$(eval GIT_COMMIT := $(shell git rev-parse HEAD))
 	$(eval GIT_DATE := $(shell git show -s --format='%ct'))
 	$(eval GIT_VERSION := $(shell git describe --tags --always 2>/dev/null || echo "dev"))
-	$(eval PLATFORM := $(or $(PLATFORM),linux/amd64))
+	$(eval TAG := $(or $(TAG),$(GIT_COMMIT)))
 	$(eval TARGETS := $(or $(TARGETS),$(DOCKER_TARGETS)))
 	$(eval KONA_VERSION := $(shell jq -r .version $(SUBMODULE)/kona/version.json))
 	@echo "Building targets: $(TARGETS)"
-	@echo "Platform: $(PLATFORM)"
+	@echo "Tag: $(TAG)"
 	@echo "Git commit: $(GIT_COMMIT)"
 	@echo "Git version: $(GIT_VERSION)"
-	@# Run docker buildx bake
-	cd $(SUBMODULE) && \
-		GIT_COMMIT=$(GIT_COMMIT) \
-		GIT_DATE=$(GIT_DATE) \
-		GIT_VERSION=$(GIT_VERSION) \
-		PLATFORMS=$(PLATFORM) \
-		KONA_VERSION=$(KONA_VERSION) \
-		docker buildx bake \
-			--progress plain \
-			--builder=buildx-build \
-			--load \
-			-f docker-bake.hcl \
-			$(TARGETS)
+	@for target in $(TARGETS); do \
+		echo ""; \
+		echo "=== Building $$target ==="; \
+		version_var=$$(echo $$target | tr '[:lower:]-' '[:upper:]_')_VERSION; \
+		podman build \
+			-f $(SUBMODULE)/ops/docker/op-stack-go/Dockerfile \
+			--target $$target-target \
+			--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+			--build-arg GIT_DATE=$(GIT_DATE) \
+			--build-arg $$version_var=$(GIT_VERSION) \
+			--build-arg KONA_VERSION=$(KONA_VERSION) \
+			-t $$target:$(TAG) \
+			$(SUBMODULE) || exit 1; \
+	done
 	@if [ "$(BOBA_KEEP_PATCHES)" != "1" ]; then \
 		$(MAKE) patch-restore; \
 	fi
-	@echo "Docker build complete."
+	@echo ""
+	@echo "Docker build complete. Images:"
+	@for target in $(TARGETS); do \
+		echo "  $$target:$(TAG)"; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ patch-apply: $(SUBMODULE)/go.mod
 			fi; \
 		done < "$(OVERLAYS)/go.mod.patch"; \
 	fi
+	@# Apply go.sum patch (uses sed script format)
+	@if [ -f "$(OVERLAYS)/go.sum.patch" ]; then \
+		sed -i -f "$(OVERLAYS)/go.sum.patch" "$(SUBMODULE)/go.sum"; \
+	fi
 	@# Apply contract overlays
 	@if [ -d "$(OVERLAYS)/contracts-bedrock/src/boba" ]; then \
 		mkdir -p "$(SUBMODULE)/packages/contracts-bedrock/src/boba"; \
@@ -119,8 +123,8 @@ patch-apply: $(SUBMODULE)/go.mod
 	@if [ -d "$(OVERLAYS)/kurtosis-devnet" ]; then \
 		cp -r "$(OVERLAYS)/kurtosis-devnet/"* "$(SUBMODULE)/kurtosis-devnet/"; \
 	fi
-	@# Apply git patch files (exclude go.mod.patch which uses sed format)
-	@for patchfile in $$(find "$(OVERLAYS)" -name "*.patch" -type f ! -name "go.mod.patch" 2>/dev/null); do \
+	@# Apply git patch files (exclude go.mod.patch and go.sum.patch which use sed format)
+	@for patchfile in $$(find "$(OVERLAYS)" -name "*.patch" -type f ! -name "go.mod.patch" ! -name "go.sum.patch" 2>/dev/null); do \
 		echo "Applying patch: $$patchfile"; \
 		(cd "$(SUBMODULE)" && patch -p1 < "$$patchfile") || true; \
 	done

--- a/overlays/go.mod.patch
+++ b/overlays/go.mod.patch
@@ -7,4 +7,4 @@
 # Pattern: s|<original>|<replacement>|g
 
 # Replace upstream op-geth with Boba's fork
-s|github.com/ethereum-optimism/op-geth v[^ ]*|github.com/bobanetwork/op-geth v0.0.0-20251216190032-bdb3c55eb405|g
+s|github.com/ethereum-optimism/op-geth v[^ ]*|github.com/bobanetwork/op-geth v0.0.0-20260114142656-ce13a07c6ec2|

--- a/overlays/go.sum.patch
+++ b/overlays/go.sum.patch
@@ -1,0 +1,14 @@
+# Boba go.sum patch
+# This patch replaces the upstream op-geth checksums with Boba's fork
+#
+# Format: Each line that starts with 's|' is a sed substitution pattern
+#         Lines starting with 'd|' are delete patterns
+#         Lines starting with 'a|' are append patterns (added after matching line)
+
+# Delete upstream op-geth checksum lines
+/github.com\/ethereum-optimism\/op-geth/d
+
+# Add bobanetwork/op-geth checksums (after the bmatcuk /go.mod line to maintain alphabetical order)
+/github.com\/bmatcuk\/doublestar.*\/go.mod/a\
+github.com/bobanetwork/op-geth v0.0.0-20260114142656-ce13a07c6ec2 h1:sOzNUI+tT9T0HieAsz1tVEaZdrwL9vofPi8kwJVHaC8=\
+github.com/bobanetwork/op-geth v0.0.0-20260114142656-ce13a07c6ec2/go.mod h1:zqJYYTNLF8vcZCNKHlgWKsmauBoeFMsrRGLAuqfzEBg=


### PR DESCRIPTION
Because we weren't ready to merge the submodule work into develop when the security bulletin was released, the op-node/v1.16.5 release was built in a separate branch.  This PR brings the work from that branch into develop so that hopefully, going forward, we can build releases out of develop instead of out of specific branches.