### PR TITLE
feat: add op-reth execution client support for node operators

### DIFF
--- a/boba-community/.env.example
+++ b/boba-community/.env.example
@@ -8,12 +8,25 @@ ERIGON_VERSION=
 # geth client version
 # The default value is the latest version of geth
 GETH_VERSION=
+# op-reth client version
+# The default value is the latest version of op-reth
+RETH_VERSION=
+# op-reth Docker image (override for locally built images)
+# Default: ghcr.io/paradigmxyz/op-reth
+# For local builds: RETH_IMAGE=localhost/op-reth
+RETH_IMAGE=
 # op-node version
 # The default value is the latest version of op-node
 OP_NODE_VERSION=
+# op-node Docker image (override for custom registries)
+# Default: us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-node
+OP_NODE_IMAGE=
 # L1 RPC URL
 # The default value is https://sepolia.gateway.tenderly.co
 ETH1_HTTP=
+# Data directory for op-reth (contains reth-data/)
+# Default: current directory
+DATA_DIR=
 # Legacy L2 HTTP PORT
 # The default value is 8545
 LEGACY_L2_HTTP_PORT=

--- a/boba-community/.env.example
+++ b/boba-community/.env.example
@@ -2,11 +2,7 @@
 ETH2_HTTP=
 
 # optional
-# erigon client version
-# The default value is the latest version of erigon
-ERIGON_VERSION=
-# geth client version
-# The default value is the latest version of geth
+# geth client version (DEPRECATED — op-geth support ends 2026-05-31, migrate to op-reth)
 GETH_VERSION=
 # op-reth client version
 # The default value is the latest version of op-reth

--- a/boba-community/README.md
+++ b/boba-community/README.md
@@ -11,76 +11,13 @@ Boba supports multiple execution clients:
 | Compose file | Execution | Consensus | Status |
 |---|---|---|---|
 | `docker-compose-boba-{network}-reth.yml` | **op-reth** | **op-node** | Recommended |
-| `docker-compose-boba-{network}.yml` | op-erigon | op-node | Supported |
-| `docker-compose-boba-{network}-geth.yml` | op-geth | op-node | Legacy |
+| `docker-compose-boba-{network}-geth.yml` | op-geth | op-node | Deprecated (removal 2026-05-31) |
 
 > **Note:** The op-reth snapshots contain a pre-initialized reth database built from the op-geth state at the Bedrock migration block. Download, extract, and run — no manual `init-state` step is needed. To regenerate the database from scratch, see the [migration guide](scripts/geth-to-reth/README.md).
 
-### Get the data dir
+### Getting started
 
-1. Download the initial data for your execution client.
-
-- BOBA Sepolia
-
-  The **erigon** db can be downloaded from [boba sepolia erigon db](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz).
-
-  ```bash
-  curl -o boba-sepolia-erigon-db.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz
-  ```
-
-  The **geth** db can be downloaded from [boba sepolia geth db](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db-20251002.tar.zst).
-
-  ```bash
-  curl -o boba-sepolia-geth-db.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db-20251002.tar.zst
-  ```
-
-  > Check the [BOBA Snapshots](https://docs.boba.network/for-developers/node-operators/snapshot-downloads) page for the correct checksum for the snapshot you've downloaded.
-
-2. Extract the data Directory
-
-   Once you've downloaded the database snapshot, you'll need to extract it to a directory on your machine. This will take some time to complete.
-
-   ```bash
-   tar xvf data.tgz
-   ```
-
-3. Create a shared secret (JWT token)
-
-   ```bash
-   openssl rand -hex 32 > jwt-secret.txt
-   ```
-
-### Create a .env file
-
-Create a  `.env` file in `boba-community`.
-
-```
-ETH1_HTTP=
-ETH2_HTTP=
-ERIGON_VERSION=
-OP_NODE_VERSION=
-```
-
-> `ETH2_HTTP` is mandatory as it is the L1 beacon endpoint. The other variables are optional, but we recommend using the latest release images. Otherwise, it will pull the image with the `latest` tag.
-
-### Modify volume location
-
-The volumes of l2 should be modified to your data directory location.
-
-```yaml
-l2:
-  volumes:
-    - ./jwt-secret.txt:/config/jwt-secret.txt
-    - DATA_DIR:/db
-```
-
-### Start your replica node
-
-For erigon + op-node (recommended):
-
-```bash
-docker compose -f docker-compose-boba-sepolia.yml up -d
-```
+See the [running a node with Docker](../boba-docs/dev-docs/node-operators/1_run-node-docker.md) guide for full setup instructions including snapshot downloads, configuration, and starting the node.
 
 ### The initial synchronization
 

--- a/boba-community/README.md
+++ b/boba-community/README.md
@@ -2,15 +2,27 @@
 
 ## Docker configuration
 
-Here are instructions if you want to run boba erigon version as the replica node for OP Mainnet or Testnet.
+Instructions for running a Boba replica node for Mainnet or Testnet.
+
+### Choose your execution client
+
+Boba supports multiple execution clients:
+
+| Compose file | Execution | Consensus | Status |
+|---|---|---|---|
+| `docker-compose-boba-{network}-reth.yml` | **op-reth** | **op-node** | Recommended |
+| `docker-compose-boba-{network}.yml` | op-erigon | op-node | Supported |
+| `docker-compose-boba-{network}-geth.yml` | op-geth | op-node | Legacy |
+
+> **Note:** The op-reth snapshots contain a pre-initialized reth database built from the op-geth state at the Bedrock migration block. Download, extract, and run — no manual `init-state` step is needed. To regenerate the database from scratch, see the [migration guide](scripts/geth-to-reth/README.md).
 
 ### Get the data dir
 
-1. The first step is to download the initial data for your execution client.
+1. Download the initial data for your execution client.
 
 - BOBA Sepolia
 
-  The **erigon** db can be downloaded from the [boba sepolia erigon db](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz).
+  The **erigon** db can be downloaded from [boba sepolia erigon db](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz).
 
   ```bash
   curl -o boba-sepolia-erigon-db.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz
@@ -43,56 +55,58 @@ Here are instructions if you want to run boba erigon version as the replica node
 Create a  `.env` file in `boba-community`.
 
 ```
-ERIGON_VERSION=
-OP_NODE_VERSION=
 ETH1_HTTP=
 ETH2_HTTP=
+ERIGON_VERSION=
+OP_NODE_VERSION=
 ```
 
-> `ETH2_HTTP` is mandatory as it is the L1 beacon endpoint. The other variables are optional, but we recommend using the latest release images for `ERIGON_VERSION` and `OP_NODE_VERSION`. Otherwise, it will pull the image with the `latest` tag.
+> `ETH2_HTTP` is mandatory as it is the L1 beacon endpoint. The other variables are optional, but we recommend using the latest release images. Otherwise, it will pull the image with the `latest` tag.
 
 ### Modify volume location
 
-The volumes of l2 and op-node should be modified to your file locations.
+The volumes of l2 should be modified to your data directory location.
 
 ```yaml
 l2:
   volumes:
     - ./jwt-secret.txt:/config/jwt-secret.txt
     - DATA_DIR:/db
-op-node:
-  volumes:
-  	- ./jwt-secret.txt:/config/jwt-secret.txt
 ```
 
 ### Start your replica node
 
+For erigon + op-node (recommended):
+
 ```bash
-docker-compose -f docker-compose-node.yml up -d
+docker compose -f docker-compose-boba-sepolia.yml up -d
 ```
 
-### The initial synchornization
+### The initial synchronization
 
-During the initial synchonization, you get log messages from `op-node`, and nothing else appears to happen.
+During the initial synchronization, you get log messages from the consensus node, and nothing else appears to happen.
 
 ```bash
 INFO [08-04|16:36:07.150] Advancing bq origin                      origin=df76ff..48987e:8301316 originBehind=false
 ```
 
-After a few minutes, `op-node` finds the right batch and then it starts synchronizing. During this synchonization process, you get log messags from `op-node`.
+After a few minutes, the node finds the right batch and then it starts synchronizing.
 
 ```bash
 INFO [08-04|16:36:01.204] Found next batch                         epoch=44e203..fef9a5:8301309 batch_epoch=8301309                batch_timestamp=1,673,567,518
 INFO [08-04|16:36:01.205] generated attributes in payload queue    txs=2  timestamp=1,673,567,518
-INFO [08-04|16:36:01.265] inserted block                           hash=ee61ee..256300 number=4,069,725 state_root=a582ae..33a7c5 timestamp=1,673,567,518 parent=5b102e..13196c prev_randao=4758ca..11ff3a fee_recipient=0x4200000000000000000000000000000000000011 txs=2  update_safe=true
 ```
+
+### Migrating from op-geth to op-reth
+
+See the [migration guide](scripts/geth-to-reth/README.md) for instructions on generating a reth database from an existing op-geth or op-erigon node.
 
 ### Optional: Run the legacy node
 
 Due to the anchorage migration, the new client does not support some RPC requests for the legacy blocks, such as `debug_transaction`. You can start the legacy node by running:
 
 ```bash
-docker-compose -f docker-compose-boba-sepolia-legacy.yml
+docker compose -f docker-compose-boba-sepolia-legacy.yml up -d
 ```
 
 The legacy Geth database can be downloaded from the [snapshot page](https://docs.boba.network/for-developers/node-operators/snapshot-downloads).

--- a/boba-community/docker-compose-boba-mainnet-reth.yml
+++ b/boba-community/docker-compose-boba-mainnet-reth.yml
@@ -1,0 +1,88 @@
+version: '3.4'
+
+# Boba Mainnet node using op-reth (execution) + op-node (consensus)
+#
+# Prerequisites:
+#   1. Download and extract the reth snapshot (see boba-docs snapshot-downloads page).
+#      Alternatively, generate the database from scratch using the init service below
+#      and the scripts in scripts/geth-to-reth/.
+#
+#   2. Create a shared JWT secret:
+#      openssl rand -hex 32 > jwt-secret.txt
+#
+#   3. Create a .env file with at minimum:
+#      ETH1_HTTP=<L1 RPC URL>
+#      ETH2_HTTP=<L1 beacon URL>
+#      OP_NODE_VERSION=<op-node image tag>
+#
+# The upstream ghcr.io/paradigmxyz/op-reth:latest image includes boba
+# as a built-in chain, so no custom build is required.
+
+services:
+  # One-time initialization: import state dump into op-reth.
+  # Place your reth-state.jsonl and header.rlp in the reth-data directory first.
+  # Run: docker compose -f docker-compose-boba-mainnet-reth.yml run --rm init
+  init:
+    image: ${RETH_IMAGE:-ghcr.io/paradigmxyz/op-reth}:${RETH_VERSION:-latest}
+    command: >
+      init-state
+      --chain=boba
+      --datadir=/db
+      --without-ovm
+      --header=/db/header.rlp
+      /db/reth-state.jsonl
+    volumes:
+      - ${DATA_DIR:-./reth-data}:/db
+    profiles:
+      - init
+
+  l2:
+    image: ${RETH_IMAGE:-ghcr.io/paradigmxyz/op-reth}:${RETH_VERSION:-latest}
+    command: >
+      node
+      --chain=boba
+      --datadir=/db
+      --http
+      --http.addr=0.0.0.0
+      --http.port=9545
+      --http.corsdomain=*
+      --http.api=eth,debug,net,web3
+      --authrpc.addr=0.0.0.0
+      --authrpc.port=8551
+      --authrpc.jwtsecret=/config/jwt-secret.txt
+      --rollup.sequencer-http=https://mainnet.boba.network
+      --rollup.disable-tx-pool-gossip
+    ports:
+      - "9545:9545"
+      - "8551:8551"
+    volumes:
+      - ./jwt-secret.txt:/config/jwt-secret.txt
+      - ${DATA_DIR:-./reth-data}:/db
+
+  op-node:
+    depends_on:
+      - l2
+    image: ${OP_NODE_IMAGE:-us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-node}:${OP_NODE_VERSION:-v1.16.2}
+    command: >
+      op-node
+      --l1=${ETH1_HTTP:-https://mainnet.gateway.tenderly.co}
+      --l1.beacon=${ETH2_HTTP}
+      --l2=http://l2:8551
+      --l2.jwt-secret=/config/jwt-secret.txt
+      --network=boba-mainnet
+      --rpc.addr=0.0.0.0
+      --rpc.port=8545
+      --p2p.bootnodes="enode://a38db98391708094dd679aacdd356efdbe10ad7c9ba4b87d8f4b79eb24ac26328e7fdf911f8c5c3b7786c2505bc77d896a0ecd1816bd56107592f728dcff3945@35.153.183.193:0?discport=30301,enode://a92b84bac2893ef868659364a6784a6eeb146cb04ec0bb3b1e9925f5bb895af9e1c50deaf0703ab26db366a3d82272e710e06d925cb0b7245129ed76d54ccac9@13.221.254.11:0?discport=30301"
+    # Optional flags
+    #  --p2p.ban.peers=false
+    #  --p2p.priv.path=/config/p2p-node-key.txt
+    #  --p2p.discovery.path=/p2p_discovery_db
+    #  --p2p.peerstore.path=/p2p_peerstore_db
+    ports:
+      - "8545:8545"
+    volumes:
+      - ./jwt-secret.txt:/config/jwt-secret.txt
+    #  - ./p2p-node-key.txt:/config/p2p-node-key.txt
+    #  - ./discovery:/p2p_discovery_db
+    #  - ./peerstore:/p2p_peerstore_db
+    restart: always

--- a/boba-community/docker-compose-boba-sepolia-reth.yml
+++ b/boba-community/docker-compose-boba-sepolia-reth.yml
@@ -1,0 +1,88 @@
+version: '3.4'
+
+# Boba Sepolia node using op-reth (execution) + op-node (consensus)
+#
+# Prerequisites:
+#   1. Download and extract the reth snapshot (see boba-docs snapshot-downloads page).
+#      Alternatively, generate the database from scratch using the init service below
+#      and the scripts in scripts/geth-to-reth/.
+#
+#   2. Create a shared JWT secret:
+#      openssl rand -hex 32 > jwt-secret.txt
+#
+#   3. Create a .env file with at minimum:
+#      ETH1_HTTP=<L1 RPC URL>
+#      ETH2_HTTP=<L1 beacon URL>
+#      OP_NODE_VERSION=<op-node image tag>
+#
+# The upstream ghcr.io/paradigmxyz/op-reth:latest image includes boba-sepolia
+# as a built-in chain, so no custom build is required.
+
+services:
+  # One-time initialization: import state dump into op-reth.
+  # Place your reth-state.jsonl and header.rlp in the reth-data directory first.
+  # Run: docker compose -f docker-compose-boba-sepolia-reth.yml run --rm init
+  init:
+    image: ${RETH_IMAGE:-ghcr.io/paradigmxyz/op-reth}:${RETH_VERSION:-latest}
+    command: >
+      init-state
+      --chain=boba-sepolia
+      --datadir=/db
+      --without-ovm
+      --header=/db/header.rlp
+      /db/reth-state.jsonl
+    volumes:
+      - ${DATA_DIR:-./reth-data}:/db
+    profiles:
+      - init
+
+  l2:
+    image: ${RETH_IMAGE:-ghcr.io/paradigmxyz/op-reth}:${RETH_VERSION:-latest}
+    command: >
+      node
+      --chain=boba-sepolia
+      --datadir=/db
+      --http
+      --http.addr=0.0.0.0
+      --http.port=9545
+      --http.corsdomain=*
+      --http.api=eth,debug,net,web3
+      --authrpc.addr=0.0.0.0
+      --authrpc.port=8551
+      --authrpc.jwtsecret=/config/jwt-secret.txt
+      --rollup.sequencer-http=https://sepolia.boba.network
+      --rollup.disable-tx-pool-gossip
+    ports:
+      - "9545:9545"
+      - "8551:8551"
+    volumes:
+      - ./jwt-secret.txt:/config/jwt-secret.txt
+      - ${DATA_DIR:-./reth-data}:/db
+
+  op-node:
+    depends_on:
+      - l2
+    image: ${OP_NODE_IMAGE:-us-docker.pkg.dev/boba-392114/bobanetwork-tools-artifacts/images/op-node}:${OP_NODE_VERSION:-v1.16.2}
+    command: >
+      op-node
+      --l1=${ETH1_HTTP:-https://sepolia.gateway.tenderly.co}
+      --l1.beacon=${ETH2_HTTP}
+      --l2=http://l2:8551
+      --l2.jwt-secret=/config/jwt-secret.txt
+      --network=boba-sepolia
+      --rpc.addr=0.0.0.0
+      --rpc.port=8545
+      --p2p.bootnodes="enode://0d9f376f90b72f65c8cbeae4c7d34732678822109412c7e8253952b207618733a736f20b43c4c7c62e95b7e6389f04cc9e9e8dbe79ba75af884b0fcf5d580a3d@54.87.50.241:0?discport=30301,enode://48eb348c252f9c527ae40dee64995a65a5a6100725b1462184bb5b86cfbe817864e8ff90b52a78124289a476a1d805b27173d8f01722160c08159fa8880c47c0@13.220.237.71:0?discport=30301"
+    # Optional flags
+    #  --p2p.ban.peers=false
+    #  --p2p.priv.path=/config/p2p-node-key.txt
+    #  --p2p.discovery.path=/p2p_discovery_db
+    #  --p2p.peerstore.path=/p2p_peerstore_db
+    ports:
+      - "8545:8545"
+    volumes:
+      - ./jwt-secret.txt:/config/jwt-secret.txt
+    #  - ./p2p-node-key.txt:/config/p2p-node-key.txt
+    #  - ./discovery:/p2p_discovery_db
+    #  - ./peerstore:/p2p_peerstore_db
+    restart: always

--- a/boba-community/scripts/geth-to-reth/README.md
+++ b/boba-community/scripts/geth-to-reth/README.md
@@ -1,0 +1,204 @@
+# Migrating op-geth State to op-reth
+
+This documents how to bootstrap an op-reth node from an existing op-geth node's state. This is needed because Boba chains migrated to Bedrock at a specific block (the "migration block"), and op-reth needs the state at that block to start syncing.
+
+Pre-built snapshots are available on the [snapshot downloads](../../boba-docs/dev-docs/node-operators/5_snapshot-downloads.md) page. If you use a pre-built snapshot, you can skip directly to running the node — the `init-state` step has already been done for you.
+
+The published migration artifacts (state dump JSONL and block header RLP) are also available on the snapshot downloads page. You can use these to independently verify or reproduce the initial reth database without needing a synced geth/erigon node.
+
+This guide is for operators who want to regenerate the database from scratch, or understand how the published snapshots were produced.
+
+## Overview
+
+1. Extract the full state from op-geth at the migration block
+2. Convert the state dump to op-reth's JSONL format
+3. Extract the migration block header as RLP
+4. Initialize op-reth with the state dump
+5. Start op-reth + op-node
+
+## Prerequisites
+
+- A running op-geth node synced to at least the migration block, with `debug` API enabled
+- `op-reth` binary (built from `optimism/rust/` workspace: `cargo build --bin op-reth --release`)
+- `jq`, `curl`, `base64`, `od` available in PATH
+- The migration block's header in RLP format (see Step 2)
+
+## Chain-Specific Parameters
+
+| Parameter | Boba Sepolia | Boba Mainnet |
+|-----------|-------------|--------------|
+| L2 Chain ID | 28882 | 288 |
+| Migration block | 511 | 1149019 |
+| L1 Chain | Sepolia (11155111) | Ethereum (1) |
+| op-reth `--chain` | `boba-sepolia` | `boba` |
+
+## Step 1: Dump all accounts from op-geth
+
+**Important**: `debug_dumpBlock` only returns 256 accounts per page and does not paginate. For blocks with more than 256 accounts, you MUST use `debug_accountRange` with pagination. The included `dump-all-accounts.sh` handles this automatically.
+
+```bash
+# Set the geth RPC endpoint (must have debug API enabled)
+export RPC_URL=http://localhost:8545
+
+# For Boba Sepolia (migration block 511 = 0x1ff):
+./dump-all-accounts.sh 0x1ff state-dump-511-full.json
+
+# For Boba Mainnet (migration block 1149019 = 0x118a5b):
+./dump-all-accounts.sh 0x118a5b state-dump-1149019-full.json
+```
+
+If dumping from an erigon node instead, use `dump-all-accounts-erigon.sh` (erigon uses slightly different RPC parameters and base64 cursors).
+
+This produces a JSON file with the structure:
+```json
+{
+  "result": {
+    "root": "<state-root-hex-no-0x>",
+    "accounts": {
+      "<address>": {
+        "balance": "<decimal>",
+        "nonce": <number>,
+        "code": "0x...",
+        "storage": { "<key>": "<value-hex-no-0x>", ... },
+        "address": "0x..."
+      }
+    }
+  }
+}
+```
+
+Verify the account count is reasonable. Boba Sepolia block 511 has 2239 accounts. Boba Mainnet will have significantly more.
+
+## Step 2: Convert to op-reth JSONL format
+
+```bash
+# For Boba Sepolia:
+./convert-to-reth.sh state-dump-511-full.json reth-state-511.jsonl
+
+# For Boba Mainnet:
+./convert-to-reth.sh state-dump-1149019-full.json reth-state-1149019.jsonl
+```
+
+The JSONL format:
+- Line 1: `{"root":"0x<state-root-hash>"}`
+- Lines 2+: One account per line with `address`, `balance`, `nonce`, `code`, `storage`
+
+Key format differences from geth:
+- **State root**: needs `0x` prefix (geth omits it)
+- **Storage values**: need `0x` prefix and zero-padded to 64 hex chars
+- **Balance/nonce**: decimal strings (op-reth accepts both decimal and hex)
+
+## Step 3: Extract the migration block header
+
+The block header must be RLP-encoded. Extract it from geth:
+
+```bash
+# Get the block header as JSON, then RLP-encode it.
+# The easiest method is to use debug_getRawHeader:
+BLOCK_HEX=0x1ff  # or 0x118a5b for mainnet
+
+curl -s -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"debug_getRawHeader\",\"params\":[\"$BLOCK_HEX\"],\"id\":1}" \
+  | jq -r '.result' > header.rlp
+```
+
+If `debug_getRawHeader` is not available, you can use `debug_getRawBlock` and strip the block body (transactions/uncles), though this requires more work.
+
+## Step 4: Initialize op-reth
+
+```bash
+# Generate a JWT secret for Engine API authentication
+openssl rand -hex 32 > jwt.hex
+
+# For Boba Sepolia:
+op-reth init-state \
+  --chain=boba-sepolia \
+  --datadir=./reth-data \
+  --without-ovm \
+  --header=header-511.rlp \
+  reth-state-511.jsonl
+
+# For Boba Mainnet:
+op-reth init-state \
+  --chain=boba \
+  --datadir=./reth-data \
+  --without-ovm \
+  --header=header-1149019.rlp \
+  reth-state-1149019.jsonl
+```
+
+The `--without-ovm` flag tells op-reth to:
+1. Create a dummy chain from block 0 to (migration_block - 1)
+2. Append the migration block header
+3. Import the state and verify the state root matches
+
+**If the state root doesn't match**, the most likely cause is an incomplete account dump (see the `debug_dumpBlock` pagination issue in Step 1).
+
+## Step 5: Start op-reth
+
+```bash
+op-reth node \
+  --chain=boba-sepolia \
+  --datadir=./reth-data \
+  --http --http.port=8545 \
+  --authrpc.port=8551 \
+  --authrpc.jwtsecret=jwt.hex \
+  --http.api=eth,net,web3,debug,txpool \
+  --ws --ws.port=8546
+```
+
+## Step 6: Start op-node
+
+op-node drives op-reth via the Engine API, deriving L2 blocks from L1 data.
+
+```bash
+op-node \
+  --l1=<L1_RPC_URL> \
+  --l1.beacon=<L1_BEACON_URL> \
+  --l2=http://localhost:8551 \
+  --l2.jwt-secret=jwt.hex \
+  --network=boba-sepolia \
+  --rpc.addr=0.0.0.0 \
+  --rpc.port=9545
+```
+
+For mainnet, use `--network=boba-mainnet` (or `--rollup.config=<path>` with a rollup config JSON).
+
+## Step 7: Verify
+
+```bash
+# Check that the block number advances past the migration block
+curl -s -X POST http://localhost:8545 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+
+# Confirm via Engine API that forkchoice is valid (requires JWT auth)
+# op-node will do this automatically during startup
+```
+
+## Troubleshooting
+
+### State root mismatch during init-state
+
+The most common cause is `debug_dumpBlock` returning only 256 accounts (its default page size). Always use `dump-all-accounts.sh` which paginates via `debug_accountRange`.
+
+To verify: compare `jq '.result.accounts | length'` between your dump and the actual account count. You can check the account count with:
+```bash
+curl -s -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"debug_accountRange\",\"params\":[\"$BLOCK_HEX\",\"0x0000000000000000000000000000000000000000000000000000000000000000\",1,false,false,false],\"id\":1}" \
+  | jq '.result'
+# Check the response — if 'next' is non-null, there are more accounts
+```
+
+### op-node stuck in "waiting for EL sync"
+
+This can happen if the Engine API forkchoice update returns SYNCING instead of VALID. Verify:
+1. op-reth is running and responsive on the auth port
+2. The JWT secret matches between op-node and op-reth
+3. op-reth was initialized with the correct chain and state
+
+### Mainnet considerations
+
+Boba Mainnet (block 1149019) will have many more accounts than Sepolia (block 511). The `dump-all-accounts.sh` script may need to run for longer. The `convert-to-reth.sh` script and `init-state` will also take longer due to the larger state. The `--without-ovm` flag generates ~1.1M dummy blocks for mainnet (vs 511 for sepolia), which takes roughly 90 seconds.

--- a/boba-community/scripts/geth-to-reth/convert-to-reth.sh
+++ b/boba-community/scripts/geth-to-reth/convert-to-reth.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Convert geth debug_dumpBlock JSON to reth init-state JSONL format
+#
+# Key format differences:
+# - storage values: geth has variable-length hex (no 0x), reth needs 0x + zero-padded to 64 hex chars
+
+INPUT="${1:?Usage: $0 <geth-dump.json> <output.jsonl>}"
+OUTPUT="${2:?Usage: $0 <geth-dump.json> <output.jsonl>}"
+
+echo "Converting $INPUT -> $OUTPUT"
+
+# Line 1: state root with 0x prefix
+jq -c '{root: ("0x" + .result.root)}' "$INPUT" > "$OUTPUT"
+
+# Remaining lines: one account per line
+# - code: already 0x-prefixed from geth, pass through
+# - storage values: zero-pad to 64 hex chars, add 0x prefix
+# - balance/nonce: pass through as decimal (reth accepts HexOrDecimal)
+jq -c '
+  # Helper: left-pad a hex string (without 0x) to 64 chars
+  def pad64: ("0" * (64 - length)) + .;
+
+  .result.accounts | to_entries[] |
+  {
+    address: (if .value.address then .value.address else .key end),
+    balance: .value.balance,
+    nonce: .value.nonce,
+    code: (if .value.code then .value.code else "0x" end),
+    storage: (
+      if .value.storage then
+        .value.storage | with_entries(.value = "0x" + (.value | pad64))
+      else {} end
+    )
+  }
+' "$INPUT" >> "$OUTPUT"
+
+LINES=$(wc -l < "$OUTPUT")
+echo "Wrote $LINES lines (1 root + $((LINES - 1)) accounts)"

--- a/boba-community/scripts/geth-to-reth/dump-all-accounts-erigon.sh
+++ b/boba-community/scripts/geth-to-reth/dump-all-accounts-erigon.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dump all accounts from erigon using debug_accountRange (handles pagination)
+# Erigon differences from geth:
+#   - 5 params instead of 6 (no 'incompletes' flag)
+#   - start key is base64, not hex
+#   - state root is 0x-prefixed
+# Usage: dump-all-accounts-erigon.sh <block-hex> <output.json>
+
+BLOCK="${1:?Usage: $0 <block-hex> <output.json>}"
+OUTPUT="${2:?Usage: $0 <block-hex> <output.json>}"
+RPC="${RPC_URL:-http://localhost:9545}"
+
+PAGE=0
+TOTAL=0
+# 32 zero bytes in base64
+START="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+echo "Dumping all accounts at block $BLOCK from $RPC (erigon mode)"
+
+while true; do
+    PAGE=$((PAGE + 1))
+    OUTFILE="$TMPDIR/page-${PAGE}.json"
+
+    curl -s -X POST "$RPC" \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"debug_accountRange\",\"params\":[\"$BLOCK\",\"${START}\",256,false,false],\"id\":${PAGE}}" \
+        > "$OUTFILE"
+
+    # Check for RPC errors
+    ERROR=$(jq -r '.error.message // empty' "$OUTFILE")
+    if [ -n "$ERROR" ]; then
+        echo "ERROR on page $PAGE: $ERROR"
+        exit 1
+    fi
+
+    COUNT=$(jq '.result.accounts | length' "$OUTFILE")
+    NEXT_B64=$(jq -r '.result.next // empty' "$OUTFILE")
+    ROOT=$(jq -r '.result.root' "$OUTFILE")
+    TOTAL=$((TOTAL + COUNT))
+
+    echo "Page $PAGE: $COUNT accounts (total: $TOTAL)"
+
+    if [ "$COUNT" -eq 0 ] || [ -z "$NEXT_B64" ]; then
+        echo "Done. Total accounts: $TOTAL"
+        break
+    fi
+
+    # Erigon returns base64 next cursor, pass directly as next start
+    START="$NEXT_B64"
+
+    if [ "$PAGE" -gt 10000 ]; then
+        echo "ERROR: Too many pages (>10000), aborting"
+        exit 1
+    fi
+done
+
+# Merge all pages into single dump
+# Strip 0x from root to match geth format (convert-to-reth.sh expects no prefix)
+echo "Merging $PAGE pages..."
+jq -s '
+    {
+        result: {
+            root: (.[0].result.root | if startswith("0x") then .[2:] else . end),
+            accounts: (reduce .[].result.accounts as $accts ({}; . + $accts))
+        }
+    }
+' "$TMPDIR"/page-*.json > "$OUTPUT"
+
+FINAL_COUNT=$(jq '.result.accounts | length' "$OUTPUT")
+echo "Wrote $OUTPUT with $FINAL_COUNT accounts"

--- a/boba-community/scripts/geth-to-reth/dump-all-accounts.sh
+++ b/boba-community/scripts/geth-to-reth/dump-all-accounts.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dump all accounts from geth using debug_accountRange (handles pagination)
+# Usage: dump-all-accounts.sh <block-hex> <output.json>
+
+BLOCK="${1:?Usage: $0 <block-hex> <output.json>}"
+OUTPUT="${2:?Usage: $0 <block-hex> <output.json>}"
+RPC="${RPC_URL:-http://localhost:9545}"
+
+PAGE=0
+TOTAL=0
+START="0x0000000000000000000000000000000000000000000000000000000000000000"
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+echo "Dumping all accounts at block $BLOCK from $RPC"
+
+while true; do
+    PAGE=$((PAGE + 1))
+    OUTFILE="$TMPDIR/page-${PAGE}.json"
+
+    curl -s -X POST "$RPC" \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"debug_accountRange\",\"params\":[\"$BLOCK\",\"${START}\",256,false,false,false],\"id\":${PAGE}}" \
+        > "$OUTFILE"
+
+    COUNT=$(jq '.result.accounts | length' "$OUTFILE")
+    NEXT_B64=$(jq -r '.result.next // empty' "$OUTFILE")
+    ROOT=$(jq -r '.result.root' "$OUTFILE")
+    TOTAL=$((TOTAL + COUNT))
+
+    echo "Page $PAGE: $COUNT accounts (total: $TOTAL)"
+
+    if [ "$COUNT" -eq 0 ] || [ -z "$NEXT_B64" ]; then
+        echo "Done. Total accounts: $TOTAL"
+        break
+    fi
+
+    # Decode base64 next cursor to hex for start parameter
+    NEXT_HEX=$(echo -n "$NEXT_B64" | base64 -d | od -A n -t x1 | tr -d ' \n')
+    START="0x${NEXT_HEX}"
+
+    if [ "$PAGE" -gt 10000 ]; then
+        echo "ERROR: Too many pages (>10000), aborting"
+        exit 1
+    fi
+done
+
+# Merge all pages into single dump with same format as debug_dumpBlock
+echo "Merging $PAGE pages..."
+jq -s '
+    {
+        result: {
+            root: .[0].result.root,
+            accounts: (reduce .[].result.accounts as $accts ({}; . + $accts))
+        }
+    }
+' "$TMPDIR"/page-*.json > "$OUTPUT"
+
+FINAL_COUNT=$(jq '.result.accounts | length' "$OUTPUT")
+echo "Wrote $OUTPUT with $FINAL_COUNT accounts"

--- a/boba-docs/dev-docs/node-operators/0_index.md
+++ b/boba-docs/dev-docs/node-operators/0_index.md
@@ -16,6 +16,11 @@ The Rollup Node is responsible for taking data from Layer 1 (L1) and use it to c
 
 The Execution Client takes care of running the block information it gets from the Rollup Node. It does this through a common method called JSON-RPC, using a set of rules known as the [Engine API](https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#engine-api----common-definitions).
 
+Boba supports multiple execution clients:
+- **op-reth** (Recommended) — High-performance Rust-based client. Uses the upstream [op-reth](https://github.com/paradigmxyz/reth) image with Boba chains built-in.
+- **op-erigon** — Go-based client, currently supported for Boba Mainnet.
+- **op-geth** — The original Go-based client, now considered legacy.
+
 ### Legacy Geth
 
 The legacy Geth database format is incompatible with the new Geth binary.  During a significant update called the [Anchorage Upgrade](https://github.com/bobanetwork/boba/blob/develop/boba-chain-ops/README.md#migration), the old blockchain state was used to initialize new starting databases for the newer execution clients.  These databases contain all of the old state (like token balances, DeFi positions, etc.), but do not contain the legacy blocks and transactions that are not compatible with the newer binaries.  To run a local copy of the node, the easiest way to start is from a copy of one of these databases. The old data from Geth, before this upgrade, can still be accessed with the new system but needs a special part called Legacy Geth to work properly. This means if you need to use certain commands, like `eth_call`, on the old data, you'll have to use Legacy Geth.

--- a/boba-docs/dev-docs/node-operators/0_index.md
+++ b/boba-docs/dev-docs/node-operators/0_index.md
@@ -18,8 +18,7 @@ The Execution Client takes care of running the block information it gets from th
 
 Boba supports multiple execution clients:
 - **op-reth** (Recommended) — High-performance Rust-based client. Uses the upstream [op-reth](https://github.com/paradigmxyz/reth) image with Boba chains built-in.
-- **op-erigon** — Go-based client, currently supported for Boba Mainnet.
-- **op-geth** — The original Go-based client, now considered legacy.
+- **op-geth** — The original Go-based client. Deprecated — support ends 2026-05-31. Migrate to op-reth.
 
 ### Legacy Geth
 
@@ -29,7 +28,7 @@ You don't always need Legacy Geth, though. It's mainly for those who want to kee
 
 ### Diagram
 
-The diagram below explains how three parts - the Rollup Node, Execution Client, and Legacy Geth - fit together to make a full Boba node. It uses examples called `op-node` for the Rollup Node and `op-erigon` for the Execution Client, but this setup is similar for other versions too.
+The diagram below explains how three parts - the Rollup Node, Execution Client, and Legacy Geth - fit together to make a full Boba node. It uses examples called `op-node` for the Rollup Node and `op-reth` for the Execution Client.
 
 ![image](../../assets/diagrams/node-operator.png)
 

--- a/boba-docs/dev-docs/node-operators/1_run-node-docker.md
+++ b/boba-docs/dev-docs/node-operators/1_run-node-docker.md
@@ -2,6 +2,18 @@
 
 This tutorial will walk you through the process of using Docker to run an BOBA Sepolia node, OP Mainnet node and OP Sepolia node. You can find all Docker Compose files [here](https://github.com/bobanetwork/boba/tree/develop/boba-community).
 
+## Choose Your Execution Client
+
+Boba supports multiple execution clients. Pick the one that suits your needs:
+
+| Compose File | Execution Client | Consensus Client | Status |
+|---|---|---|---|
+| `docker-compose-boba-{network}-reth.yml` | **op-reth** | **op-node** | Recommended |
+| `docker-compose-boba-{network}.yml` | op-erigon | op-node | Supported |
+| `docker-compose-boba-{network}-geth.yml` | op-geth | op-node | Legacy |
+
+> **op-reth** is the recommended execution client for new deployments. It uses the upstream [op-reth](https://github.com/paradigmxyz/reth) image with Boba chains built-in — no custom build is required.
+
 ## Prerequisites
 
 * [docker](https://docs.docker.com/engine/install/)
@@ -35,11 +47,46 @@ Open the `.env` in your directory and set the variables inside. Read the descrip
 
 ## DB Configuration
 
+### Create a Shared Secret (JWT Token)
+
+```bash
+openssl rand -hex 32 > jwt-secret.txt
+```
+
 ### Download Snapshots
 
-You can download the database snapshot for the client and network you wish to run.
+Download the database snapshot for the client and network you wish to run. Always verify snapshots by comparing the sha256sum of the downloaded file to the sha256sum listed on the [snapshot downloads](snapshot-downloads) page.
 
-Always verify snapshots by comparing the sha256sum of the downloaded file to the sha256sum listed on this [page](snapshot-downloads). Check the sha256sum of the downloaded file by running `sha256sum <filename>`in a terminal.
+```bash
+sha256sum <filename>
+```
+
+#### op-reth (Recommended)
+
+* BOBA Mainnet
+
+  ```bash
+  curl -o boba-mainnet-reth-db-20260320.tar.zst -sL https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-reth-db-20260320.tar.zst
+  ```
+
+* BOBA Sepolia
+
+  ```bash
+  curl -o boba-sepolia-reth-db-20260415.tar.zst -sL https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-reth-db-20260415.tar.zst
+  ```
+
+Extract the snapshot into a `reth-data` directory:
+
+```bash
+mkdir -p reth-data
+tar --zstd -xf boba-{network}-reth-db-initial.tar.zst -C reth-data
+```
+
+These snapshots contain a pre-initialized reth database built from the op-geth state at the Bedrock migration block (block 1149019 for mainnet, block 511 for sepolia). No manual `init-state` step is needed — just extract and run. To regenerate the database from scratch, see the [migration guide](https://github.com/bobanetwork/boba/tree/develop/boba-community/scripts/geth-to-reth).
+
+Set the `DATA_DIR` in your `.env` to point to this directory (or leave it blank to use the default `./reth-data`).
+
+#### op-erigon / op-geth
 
 * BOBA Mainnet
 
@@ -52,7 +99,7 @@ Always verify snapshots by comparing the sha256sum of the downloaded file to the
   The **geth** db can be downloaded from [boba mainnet geth db](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-db-20251010.tar.zst)
 
   ```bash
-  curl -o boba-mainnet-geth-db-114909.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-db-20251010.tar.zst
+  curl -o boba-mainnet-geth-db.tar.zst -sL https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-db-20251010.tar.zst
   ```
 
 - BOBA Sepolia
@@ -69,18 +116,10 @@ Always verify snapshots by comparing the sha256sum of the downloaded file to the
   curl -o boba-sepolia-geth-db.tar.zst -sL https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db-20251002.tar.zst
   ```
 
-### Extract Snapshots
-
-Once you've downloaded the database snapshot, you'll need to extract it to a directory on your machine. This will take some time to complete.
+Extract erigon/geth snapshots:
 
 ```bash
 tar xvf data.tgz
-```
-
-### Create a Shared Secret (JWT Token)
-
-```bash
-openssl rand -hex 32 > jwt-secret.txt
 ```
 
 ### Modify Volume Location
@@ -99,18 +138,36 @@ op-node:
 
 ## Run the Node
 
-Once you've configured your `.env` file, you can run the node using Docker Compose. The following command will start the node in the background.
+Once you've configured your `.env` file, you can run the node using Docker Compose.
+
+### op-reth (Recommended)
 
 ```bash
-docker-compose -f [docker-compose-file] up -d
+# BOBA Mainnet
+docker compose -f docker-compose-boba-mainnet-reth.yml up -d
+
+# BOBA Sepolia
+docker compose -f docker-compose-boba-sepolia-reth.yml up -d
 ```
 
-## Optional: Run the Node with Geth
-
-We support both geth and erigon as the execution engines for Boba Mainnet node. You can start the node with geth using the following command:
+### op-erigon
 
 ```bash
-docker-compose -f docker-compose-mainnet-geth.yml up -d
+# BOBA Sepolia
+docker compose -f docker-compose-boba-sepolia.yml up -d
+
+# BOBA Mainnet
+docker compose -f docker-compose-boba-mainnet.yml up -d
+```
+
+### op-geth (Legacy)
+
+```bash
+# BOBA Sepolia
+docker compose -f docker-compose-boba-sepolia-geth.yml up -d
+
+# BOBA Mainnet
+docker compose -f docker-compose-boba-mainnet-geth.yml up -d
 ```
 
 ## Operating the Node

--- a/boba-docs/dev-docs/node-operators/1_run-node-docker.md
+++ b/boba-docs/dev-docs/node-operators/1_run-node-docker.md
@@ -9,8 +9,7 @@ Boba supports multiple execution clients. Pick the one that suits your needs:
 | Compose File | Execution Client | Consensus Client | Status |
 |---|---|---|---|
 | `docker-compose-boba-{network}-reth.yml` | **op-reth** | **op-node** | Recommended |
-| `docker-compose-boba-{network}.yml` | op-erigon | op-node | Supported |
-| `docker-compose-boba-{network}-geth.yml` | op-geth | op-node | Legacy |
+| `docker-compose-boba-{network}-geth.yml` | op-geth | op-node | Deprecated (removal 2026-05-31) |
 
 > **op-reth** is the recommended execution client for new deployments. It uses the upstream [op-reth](https://github.com/paradigmxyz/reth) image with Boba chains built-in — no custom build is required.
 
@@ -86,37 +85,13 @@ These snapshots contain a pre-initialized reth database built from the op-geth s
 
 Set the `DATA_DIR` in your `.env` to point to this directory (or leave it blank to use the default `./reth-data`).
 
-#### op-erigon / op-geth
+#### op-geth (Deprecated)
 
-* BOBA Mainnet
+> **Deprecated:** op-geth support ends 2026-05-31. Migrate to op-reth.
 
-  The **erigon** db can be downloaded from the [boba mainnet erigon db](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-erigon-db-1149019.tgz).
+See the [snapshot downloads](snapshot-downloads) page for available geth snapshots.
 
-  ```bash
-  curl -o boba-mainnet-erigon-db-1149019.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-erigon-db-1149019.tgz
-  ```
-
-  The **geth** db can be downloaded from [boba mainnet geth db](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-db-20251010.tar.zst)
-
-  ```bash
-  curl -o boba-mainnet-geth-db.tar.zst -sL https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-db-20251010.tar.zst
-  ```
-
-- BOBA Sepolia
-
-  The **erigon** db can be downloaded from the [boba sepolia erigon db](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz).
-
-  ```bash
-  curl -o boba-sepolia-erigon-db.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz
-  ```
-
-  The **geth** db can be downloaded from [boba sepolia geth db](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db-20251002.tar.zst).
-
-  ```bash
-  curl -o boba-sepolia-geth-db.tar.zst -sL https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db-20251002.tar.zst
-  ```
-
-Extract erigon/geth snapshots:
+Extract geth snapshots:
 
 ```bash
 tar xvf data.tgz
@@ -150,17 +125,7 @@ docker compose -f docker-compose-boba-mainnet-reth.yml up -d
 docker compose -f docker-compose-boba-sepolia-reth.yml up -d
 ```
 
-### op-erigon
-
-```bash
-# BOBA Sepolia
-docker compose -f docker-compose-boba-sepolia.yml up -d
-
-# BOBA Mainnet
-docker compose -f docker-compose-boba-mainnet.yml up -d
-```
-
-### op-geth (Legacy)
+### op-geth (Deprecated — removal 2026-05-31)
 
 ```bash
 # BOBA Sepolia

--- a/boba-docs/dev-docs/node-operators/2_run-node-source.md
+++ b/boba-docs/dev-docs/node-operators/2_run-node-source.md
@@ -54,68 +54,29 @@ Build the `op-node`.
 make op-node
 ```
 
-## Build the Execution Engine
+## Build the Execution Engine (op-reth)
 
-### Clone the Erigon repo
-
-```bash
-git clone https://github.com/bobanetwork/op-erigon.git
-cd op-erigon
-```
-
-### Check out the required release branch
-
-Release branches are created when new versions of the `erigon` are created. Read through the [Releases page](https://github.com/bobanetwork/op-erigon/releases) to determine the correct branch to check out.
-
-```
-git checkout <name of release branch>
-```
-
-### Build erigon
-
-Build the `erigon`.
+The recommended execution client is op-reth. The upstream [op-reth](https://github.com/paradigmxyz/reth) includes Boba chains as built-in, so you can build directly from upstream.
 
 ```bash
-make erigon
+git clone https://github.com/paradigmxyz/reth.git
+cd reth
+cargo build --bin op-reth --release
 ```
+
+The binary will be at `target/release/op-reth`.
 
 ## Download Snapshots
 
-You can download the database snapshot for the client and network you wish to run.
+Download the database snapshot for your network from the [snapshot downloads](snapshot-downloads) page. Always verify snapshots by comparing the sha256sum of the downloaded file to the sha256sum listed on that page.
 
-Always verify snapshots by comparing the sha256sum of the downloaded file to the sha256sum listed on this [page](snapshot-downloads). Check the sha256sum of the downloaded file by running `sha256sum <filename>`in a terminal.
-
-* BOBA Mainnet
-
-  The **erigon** db can be downloaded from the [boba mainnet erigon db](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-erigon-db-1149019.tgz).
-
-  ```bash
-  curl -o boba-mainnet-erigon-db-1149019.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-erigon-db-1149019.tgz
-  ```
-
-  The **geth** db can be downloaded from [boba mainnet geth db](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-db-20251010.tar.zst)
-
-  ```bash
-  curl -o boba-mainnet-geth-db-114909.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-db-20251010.tar.zst
-  ```
-
-- BOBA Sepolia
-
-  The **erigon** db can be downloaded from the [boba sepolia erigon db](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz).
-
-  ```bash
-  curl -o boba-sepolia-erigon-db.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz
-  ```
-
-  The **geth** db can be downloaded from [boba sepolia geth db](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db-20251002.tar.zst).
-
-  ```bash
-  curl -o boba-sepolia-geth-db.tgz -sL https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db-20251002.tar.zst
-  ```
+```bash
+sha256sum <filename>
+```
 
 ## Create a JWT Secret
 
-`op-erigon` and `op-node` communicate over the engine API authrpc. This communication is secured using a shared secret. You will need to generate a shared secret and provide it to both `op-erigon` and `op-node` when you start them. In this case, the secret takes the form of a 32 byte hex string.
+`op-reth` and `op-node` communicate over the engine API authrpc. This communication is secured using a shared secret. You will need to generate a shared secret and provide it to both `op-reth` and `op-node` when you start them. In this case, the secret takes the form of a 32 byte hex string.
 
 Run the following command to generate a random 32 byte hex string:
 
@@ -123,63 +84,33 @@ Run the following command to generate a random 32 byte hex string:
 openssl rand -hex 32 > jwt.txt
 ```
 
-## Start `op-erigon`
+## Start `op-reth`
 
-It's usually simpler to begin with `op-erigon` before you start `op-node`. You can start `op-erigon` even if `op-node` isn't running yet, but `op-erigon` won't get any blocks until `op-node` starts.
+It's usually simpler to begin with `op-reth` before you start `op-node`. You can start `op-reth` even if `op-node` isn't running yet, but `op-reth` won't get any blocks until `op-node` starts.
 
-### Navigate to your op-erigon directory
-
-```bash
-cd op-erigon
-```
-
-### Copy in the JWT secret
-
-Copy the JWT secret you generated in the previous step into the `v3-erigon` directory.
+Using the following command to start `op-reth` in a default configuration. The JSON-RPC API will become available on port 9545.
 
 ```bash
-cp /path/to/jwt.txt .
+op-reth node \
+  --chain=boba-sepolia \
+  --datadir=./reth-data \
+  --http \
+  --http.addr=0.0.0.0 \
+  --http.port=9545 \
+  --http.corsdomain="*" \
+  --http.api=eth,debug,net,web3 \
+  --authrpc.addr=0.0.0.0 \
+  --authrpc.port=8551 \
+  --authrpc.jwtsecret=./jwt.txt \
+  --rollup.sequencer-http=https://sepolia.boba.network \
+  --rollup.disable-tx-pool-gossip
 ```
 
-### Start op-erigon
-
-Using the following command to start `op-erigon` in a default configuration. The JSON-RPC API will become available on port 9545.
-
-```bash
-./build/bin/erigon \
-	--datadir=$DBDIR_PATH \
-	--private.api.addr=localhost:9090 \
-	--http.addr=0.0.0.0 \
-	--http.port=9545 \
-	--http.corsdomain="*" \
-	--http.vhosts="*" \
-	--authrpc.addr=0.0.0.0 \
-	--authrpc.port=8551 \
-	--authrpc.vhosts="*" \
-	--authrpc.jwtsecret=./jwt.txt \
-	--chain=boba-sepolia \
-	--http.api=eth,debug,net,engine,web3 \
-	--rollup.sequencerhttp=https://mainnet.boba.network \
-	--db.size.limit=8TB
-```
+For mainnet, use `--chain=boba` and `--rollup.sequencer-http=https://mainnet.boba.network`.
 
 ## Start `op-node`
 
-Once you've started `op-erigon`, you can start `op-node`. `op-node` will connect to `op-erigon` and begin synchronizing the BOBA network. `op-node` will begin sending block payloads to `op-erigon` when it derives enough blocks from Ethereum.
-
-### Navigate to your op-node directory
-
-```bash
-cd op-node
-```
-
-### Copy in the JWT secret
-
-Copy the JWT secret you generated in the previous step into the `v3-erigon` directory.
-
-```bash
-cp /path/to/jwt.txt .
-```
+Once you've started `op-reth`, you can start `op-node`. `op-node` will connect to `op-reth` and begin synchronizing the BOBA network. `op-node` will begin sending block payloads to `op-reth` when it derives enough blocks from Ethereum.
 
 ### Set environment variables
 
@@ -203,15 +134,15 @@ Using the following command to start `op-node` in a default configuration. The J
   --rpc.port=8545
 ```
 
-## Synchornization
+## Synchronization
 
-During the initial synchonization, you get log messages from `op-node`, and nothing else appears to happen.
+During the initial synchronization, you get log messages from `op-node`, and nothing else appears to happen.
 
 ```bash
 INFO [08-04|16:36:07.150] Advancing bq origin                      origin=df76ff..48987e:8301316 originBehind=false
 ```
 
-After a few minutes, `op-node` finds the right batch and then it starts synchronizing. During this synchonization process, you get log messags from `op-node`.
+After a few minutes, `op-node` finds the right batch and then it starts synchronizing.
 
 ```bash
 INFO [08-04|16:36:01.204] Found next batch                         epoch=44e203..fef9a5:8301309 batch_epoch=8301309                batch_timestamp=1,673,567,518

--- a/boba-docs/dev-docs/node-operators/5_snapshot-downloads.md
+++ b/boba-docs/dev-docs/node-operators/5_snapshot-downloads.md
@@ -10,10 +10,21 @@ Always verify snapshots by comparing the sha256sum of the downloaded file to the
 
 | Client | Snapshot Date | Size     | Download Link                                                | Sha256sum                                                    |
 | ------ | ------------- | -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Reth   | 2026-03-20    | -        | [Link](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-reth-db-20260320.tar.zst) | `ed8dbdab30d01612b2797276274315579be60413a3509e783f1ee462fa1b6f80` |
+| Reth   | initial (block 1149019) | 74MB     | [Link](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-reth-db-initial.tar.zst) | `22b26c59ecbfc7b8f77525dc210d1780aa2bbf072084aae2b9d2e88b1f1d3301` |
 | Erigon | 2024-04-16    | 1016.4MB | [Link](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-erigon-db-1149019.tgz) | `98bfd73716585f412a6388bb51a8bfb945170d0d228efb4d218d98d523d76168` |
 | Geth   | 2024-04-16    | 16.3GB   | [Link](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-db-114909.tgz) | `102922968680e86afe0588cf22924639f6f2ab32aee1c1e2325c3026b262692b` |
 | Geth   | 2024-07-30    | 49.7GB   | [Link](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-snapshot-5683043.tgz) | `9d20e16434bbdb8d2fdcdfee848f7941337e6b2cfb8feece441820c9a6364d09` |
 | Geth   | 2025-10-10    | 146GB   | [Link](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-geth-db-20251010.tar.zst) | `4f4c0a1d2376382110ecc90d46329850222feaedd9d320b146c326359d5b1353` |
+
+### BOBA Mainnet (Reth Migration Artifacts)
+
+These are the source artifacts used to generate the initial reth database via `op-reth init-state`. They allow independent verification and reproducibility without needing a synced geth/erigon node.
+
+| File | Description | Size | Download Link | Sha256sum |
+| ---- | ----------- | ---- | ------------- | --------- |
+| State dump | All accounts at migration block 1149019 in reth JSONL format | 150MB | [Link](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-reth-state-initial.jsonl) | `1b226876bf6de17deed4865226ad87c77fd57dd43f47f67d5c870d937396463a` |
+| Block header | RLP-encoded header for block 1149019 | 508B | [Link](https://boba-db.s3.us-east-2.amazonaws.com/mainnet/boba-mainnet-reth-header-initial.rlp) | `323a5337d151204724817a826d7846cb29a7aef0738448c9c0dd9250a8402eb8` |
 
 ### BOBA Mainnet (Legacy)
 
@@ -25,11 +36,20 @@ Always verify snapshots by comparing the sha256sum of the downloaded file to the
 
 | Client | Snapshot Date | Size  | Download Link                                                | Sha256sum                                                    |
 | ------ | ------------- | ----- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Reth   | 2026-04-15    | -     | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-reth-db-20260415.tar.zst) | `56b5deb405c74d294e4ddbf6f32ce59f812f12dd5047e053e175828eda8e2c15` |
+| Reth   | initial (block 511) | 343KB | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-reth-db-initial.tar.zst) | `703cb2c0c33a4689d7cfabb10483e7ec0900068f597da9455db0dcba06a9d8bf` |
 | Erigon | 2024-01-18    | 912KB | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-db.tgz) | `b887d2e0318e9299e844da7d39ca32040e3d0fb6a9d7abe2dd2f8624eca1cade` |
 | Geth   | 2024-01-18    | 2MB   | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db.tgz) | `b229c8e51e41a26bb21a84b329d3134ae5cc6541b04eb160aebd573f0e6b94ae` |
 | Erigon | 2024-02-13    | 586M  | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-snapshot-1126371.tgz) | `688fd431656b673d3f2c690d79277b6d659a51c48c7b73a5e36bb8fbfdbdea80` |
 | Erigon | 2024-3-01     | 956M  | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-erigon-snapshot-1857820.tgz) | `3464fa9c1f669ad3d26359e5c463c33d3d60735a7aafb8e10d2dfd4719a71c07` |
 | Geth   | 2025-10-02    | 135GB   | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-geth-db-20251002.tar.zst) | `578cdc9ae438986a7895e3c16485e8268c2eae9fafa622dd3f0c778b30a2a5a8` |
+
+### BOBA Sepolia Testnet (Reth Migration Artifacts)
+
+| File | Description | Size | Download Link | Sha256sum |
+| ---- | ----------- | ---- | ------------- | --------- |
+| State dump | All accounts at migration block 511 in reth JSONL format | 1.1MB | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-reth-state-initial.jsonl) | `79dbeaaff89db3422ff057b67e78f3a576494213e5927347ce6f22cc829c0943` |
+| Block header | RLP-encoded header for block 511 | 1KB | [Link](https://boba-db.s3.us-east-2.amazonaws.com/sepolia/boba-sepolia-reth-header-initial.rlp) | `0514713a96e46856b3db8618d2c76c98433e1e506431f47c76473d77b5a676b8` |
 
 ### BOBA Sepolia Testnet (Legacy)
 

--- a/boba-docs/dev-docs/node-operators/6_software-release.md
+++ b/boba-docs/dev-docs/node-operators/6_software-release.md
@@ -6,12 +6,12 @@ Our latest releases, notes and changelogs can be found on Github. `op-node` rele
 
 ## Required Version by Network
 
-These are the minimal required versions for node software by network. **op-reth is the recommended execution client for new deployments.**
+These are the minimal required versions for node software by network. **op-reth is the recommended execution client.** op-geth is deprecated and will be removed on 2026-05-31. op-erigon is no longer supported.
 
-| Network          | op-node                                                      | op-reth | op-erigon                                                    | op-geth                                                      |
-| ---------------- | ------------------------------------------------------------ | ------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| Boba Mainnet | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [latest](https://github.com/paradigmxyz/reth/pkgs/container/op-reth) | [v1.2.12-beta.1](https://github.com/bobanetwork/op-erigon/releases/tag/v1.2.12-beta.1) | [v1.101500.0](https://github.com/bobanetwork/op-geth/releases/tag/v1.101503.0) |
-| Boba Sepolia | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [latest](https://github.com/paradigmxyz/reth/pkgs/container/op-reth) | currently unsupported | [v1.101603.1](https://github.com/bobanetwork/op-geth/releases/tag/v1.101603.1) |
+| Network          | op-node                                                      | op-reth | op-geth (deprecated)                                         |
+| ---------------- | ------------------------------------------------------------ | ------- | ------------------------------------------------------------ |
+| Boba Mainnet | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [latest](https://github.com/paradigmxyz/reth/pkgs/container/op-reth) | [v1.101500.0](https://github.com/bobanetwork/op-geth/releases/tag/v1.101503.0) |
+| Boba Sepolia | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [latest](https://github.com/paradigmxyz/reth/pkgs/container/op-reth) | [v1.101603.1](https://github.com/bobanetwork/op-geth/releases/tag/v1.101603.1) |
 
 > **Note:** op-reth uses the upstream [ghcr.io/paradigmxyz/op-reth](https://github.com/paradigmxyz/reth/pkgs/container/op-reth) image which includes `boba-sepolia` and `boba` as built-in chains. No custom build is required.
 
@@ -27,13 +27,7 @@ Upgrade your `op-node` software.
 
 ## op-erigon
 
-**Description**
-
-Unfortunately, op-erigon does not currently support Fusaka, once support is available, this page will be updated.
-
-**Required Action**
-
-Migrate to op-reth (recommended) or op-geth for uninterrupted support. See the [running a node](1_run-node-docker.md) guide for op-reth setup instructions.
+op-erigon is no longer supported. Migrate to op-reth. See the [running a node](1_run-node-docker.md) guide for setup instructions.
 
 ## [op-geth v1.101603.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.1)
 

--- a/boba-docs/dev-docs/node-operators/6_software-release.md
+++ b/boba-docs/dev-docs/node-operators/6_software-release.md
@@ -6,12 +6,14 @@ Our latest releases, notes and changelogs can be found on Github. `op-node` rele
 
 ## Required Version by Network
 
-These are the minimal required versions for the `op-node`, `op-erigon` and `op-geth` by network.
+These are the minimal required versions for node software by network. **op-reth is the recommended execution client for new deployments.**
 
-| Network          | op-node                                                      | op-erigon                                                    | op-geth                                                      |
-| ---------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| Boba Mainnet | [v1.6.16](https://github.com/bobanetwork/boba/releases/tag/v1.6.17) | [v1.2.12-beta.1](https://github.com/bobanetwork/op-erigon/releases/tag/v1.2.12-beta.1) | [v1.101500.0](https://github.com/bobanetwork/op-geth/releases/tag/v1.101503.0) |
-| Boba Sepolia | [v1.14.1](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.6.17) | currently unsupported | [v1.101603.1](https://github.com/bobanetwork/op-geth/releases/tag/v1.101603.1) |
+| Network          | op-node                                                      | op-reth | op-erigon                                                    | op-geth                                                      |
+| ---------------- | ------------------------------------------------------------ | ------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Boba Mainnet | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [latest](https://github.com/paradigmxyz/reth/pkgs/container/op-reth) | [v1.2.12-beta.1](https://github.com/bobanetwork/op-erigon/releases/tag/v1.2.12-beta.1) | [v1.101500.0](https://github.com/bobanetwork/op-geth/releases/tag/v1.101503.0) |
+| Boba Sepolia | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [latest](https://github.com/paradigmxyz/reth/pkgs/container/op-reth) | currently unsupported | [v1.101603.1](https://github.com/bobanetwork/op-geth/releases/tag/v1.101603.1) |
+
+> **Note:** op-reth uses the upstream [ghcr.io/paradigmxyz/op-reth](https://github.com/paradigmxyz/reth/pkgs/container/op-reth) image which includes `boba-sepolia` and `boba` as built-in chains. No custom build is required.
 
 ## [op-node v1.14.1](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.14.1)
 
@@ -31,7 +33,7 @@ Unfortunately, op-erigon does not currently support Fusaka, once support is avai
 
 **Required Action**
 
-Migrate to op-geth for uninterrupted support
+Migrate to op-reth (recommended) or op-geth for uninterrupted support. See the [running a node](1_run-node-docker.md) guide for op-reth setup instructions.
 
 ## [op-geth v1.101603.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.1)
 


### PR DESCRIPTION
Add docker-compose files, database snapshots, and documentation for running Boba nodes with op-reth (upstream) + op-node. The upstream ghcr.io/paradigmxyz/op-reth image includes boba and boba-sepolia as built-in chains, requiring no custom build.

- Add docker-compose-boba-{mainnet,sepolia}-reth.yml with init profile
- Add reth initial database snapshots (mainnet 74MB, sepolia 343KB)
- Add mainnet reth snapshot from 2026-03-20
- Publish migration artifacts (state dump JSONL + block header RLP) for independent verification and reproducibility
- Update boba-docs with op-reth download, setup, and run instructions
- Add RETH_IMAGE, OP_NODE_IMAGE, DATA_DIR to .env.example
- Add geth-to-reth migration scripts and documentation