### PR TITLE
chore: update op-reth and op-node versions

### DIFF
--- a/boba-community/.env.example
+++ b/boba-community/.env.example
@@ -3,7 +3,7 @@ ETH2_HTTP=
 
 # optional
 # op-reth client version
-# Default: v2.2.1
+# Default: v2.3.1
 RETH_VERSION=
 # op-reth Docker image (override for locally built images)
 # Default: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth

--- a/boba-community/chainspecs/README.md
+++ b/boba-community/chainspecs/README.md
@@ -44,11 +44,11 @@ If the upstream PR linked above lands and we then push the missing `bedrockBlock
 To regenerate from the upstream bundled spec:
 
 ```bash
-docker run --rm us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.2.1 dump-genesis --chain boba 2>/dev/null \
+docker run --rm us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.3.1 dump-genesis --chain boba 2>/dev/null \
   | tail -n +2 \
   | jq '.config.bedrockBlock = 1149019' > boba.json
 
-docker run --rm us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.2.1 dump-genesis --chain boba-sepolia 2>/dev/null \
+docker run --rm us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.3.1 dump-genesis --chain boba-sepolia 2>/dev/null \
   | tail -n +2 \
   | jq '.config.bedrockBlock = 511' > boba-sepolia.json
 ```
@@ -60,9 +60,9 @@ docker run --rm us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.2.1 d
 To diff the patched chain spec against the upstream built-in spec and confirm the only difference is `bedrockBlock`:
 
 ```bash
-docker run --rm us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.2.1 dump-genesis --chain boba 2>/dev/null \
+docker run --rm us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.3.1 dump-genesis --chain boba 2>/dev/null \
   | tail -n +2 > /tmp/upstream.json
-docker run --rm -v "$PWD:/cs" us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.2.1 \
+docker run --rm -v "$PWD:/cs" us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.3.1 \
   dump-genesis --chain /cs/boba.json 2>/dev/null | tail -n +2 > /tmp/ours.json
 diff /tmp/upstream.json /tmp/ours.json
 # Expected: a single hunk replacing "bedrockBlock": 0 with "bedrockBlock": 1149019

--- a/boba-community/docker-compose-boba-mainnet.yml
+++ b/boba-community/docker-compose-boba-mainnet.yml
@@ -84,7 +84,7 @@ services:
   # Place your reth-state.jsonl and header.rlp in the data directory first.
   # Run: docker compose -f docker-compose-boba-mainnet.yml --profile init run --rm init
   init:
-    image: ${RETH_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth}:${RETH_VERSION:-v2.2.1}
+    image: ${RETH_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth}:${RETH_VERSION:-v2.3.1}
     command: >
       init-state
       --chain=/config/boba.json
@@ -99,7 +99,7 @@ services:
       - init
 
   l2:
-    image: ${RETH_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth}:${RETH_VERSION:-v2.2.1}
+    image: ${RETH_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth}:${RETH_VERSION:-v2.3.1}
     command: >
       node
       --chain=/config/boba.json
@@ -132,7 +132,7 @@ services:
   op-node:
     depends_on:
       - l2
-    image: ${OP_NODE_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node}:${OP_NODE_VERSION:-v1.16.5}
+    image: ${OP_NODE_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node}:${OP_NODE_VERSION:-v1.19.0}
     command: >
       op-node
       --l1=${ETH1_HTTP:-https://mainnet.gateway.tenderly.co}

--- a/boba-community/docker-compose-boba-sepolia.yml
+++ b/boba-community/docker-compose-boba-sepolia.yml
@@ -84,7 +84,7 @@ services:
   # Place your reth-state.jsonl and header.rlp in the data directory first.
   # Run: docker compose -f docker-compose-boba-sepolia.yml --profile init run --rm init
   init:
-    image: ${RETH_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth}:${RETH_VERSION:-v2.2.1}
+    image: ${RETH_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth}:${RETH_VERSION:-v2.3.1}
     command: >
       init-state
       --chain=/config/boba-sepolia.json
@@ -99,7 +99,7 @@ services:
       - init
 
   l2:
-    image: ${RETH_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth}:${RETH_VERSION:-v2.2.1}
+    image: ${RETH_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth}:${RETH_VERSION:-v2.3.1}
     command: >
       node
       --chain=/config/boba-sepolia.json
@@ -132,7 +132,7 @@ services:
   op-node:
     depends_on:
       - l2
-    image: ${OP_NODE_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node}:${OP_NODE_VERSION:-v1.16.5}
+    image: ${OP_NODE_IMAGE:-us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node}:${OP_NODE_VERSION:-v1.19.0}
     command: >
       op-node
       --l1=${ETH1_HTTP:-https://sepolia.gateway.tenderly.co}

--- a/boba-docs/dev-docs/node-operators/6_software-release.md
+++ b/boba-docs/dev-docs/node-operators/6_software-release.md
@@ -10,8 +10,8 @@ These are the minimal required versions for node software by network. **op-reth 
 
 | Network          | op-node                                                      | op-reth                                                        |
 | ---------------- | ------------------------------------------------------------ | -------------------------------------------------------------- |
-| Boba Mainnet | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [v2.2.1](https://github.com/ethereum-optimism/op-reth/releases) |
-| Boba Sepolia | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [v2.2.1](https://github.com/ethereum-optimism/op-reth/releases) |
+| Boba Mainnet | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [v2.3.1](https://github.com/ethereum-optimism/op-reth/releases) |
+| Boba Sepolia | [v1.16.5](https://github.com/bobanetwork/boba/releases/tag/op-node/v1.16.5) | [v2.3.1](https://github.com/ethereum-optimism/op-reth/releases) |
 
 > **Note:** op-reth and op-node are both published by OP Labs (`us-docker.pkg.dev/oplabs-tools-artifacts/images/{op-reth,op-node}`). Neither image includes Boba as a built-in network — the Boba chain spec for op-reth is supplied via a mounted JSON file, and the Boba rollup config for op-node likewise. See [`boba-community/chainspecs/`](https://github.com/bobanetwork/boba/tree/develop/boba-community/chainspecs) and [`boba-community/rollup-configs/`](https://github.com/bobanetwork/boba/tree/develop/boba-community/rollup-configs) for the JSON files and their regeneration procedures.
 


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

## Overview

Updates our docker-compose files to use op-reth 2.3.1 and op-node 1.19.0, which are 
noted as "mandatory release for all node operators" upstream. The op-reth version bump
is only from 2.2.1. However op-node was previously at 1.16.5 and so this represents a
significant update. Please refer to the upstream changelogs for any potential issues such
as new command line parameters.

https://github.com/ethereum-optimism/optimism/releases

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Change 1
- Change 2
- ...

## Testing

Describe how to test your new feature/bug fix and if possible, a step by step guide on how to demo this.
