### PR TITLE
docs: add Isthmus/Jovian breaking-changes notice for Boba Sepolia

### DIFF
--- a/boba-docs/dev-docs/notices/89_isthmus-jovian-breaking-changes.md
+++ b/boba-docs/dev-docs/notices/89_isthmus-jovian-breaking-changes.md
@@ -1,0 +1,43 @@
+# Preparing for Isthmus and Jovian breaking changes
+
+The Isthmus and Jovian upgrades for Boba Sepolia require mandatory upgrades for node operators. Both are activated by timestamp:
+
+* Isthmus (Boba Sepolia): 1787227200 (Thursday, August 20, 2026 at 12:00:00 UTC)
+* Jovian (Boba Sepolia): 1787659200 (Tuesday, August 25, 2026 at 12:00:00 UTC)
+
+Isthmus also activates the Prague EVM (`pragueTime`) at the same timestamp as Isthmus.
+
+Boba Mainnet activation dates are not yet scheduled and will be announced in a future update to this notice.
+
+:::warning
+These hardforks are not yet included in the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry). Until they are, the activation times are **not** present in the Boba Sepolia config bundled into the upstream `op-reth` / `op-node` images. Running with the built-in `--chain=boba-sepolia` / `--network=boba-sepolia` will derive against a stale fork schedule and diverge at the fork boundary. You **must** supply the Boba Sepolia chain spec and rollup config JSON files at runtime — see [Supply the Boba Sepolia config files](#supply-the-boba-sepolia-config-files-mandatory) below.
+:::
+
+## For Node Operators
+
+Node operators are required to upgrade before the activation dates to avoid chain divergence.
+
+### Update to the latest release
+
+* op-reth at `v2.3.1` — image `us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.3.1`
+* op-node at `v1.19.0` — image `us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.19.0`
+
+:::note
+op-geth and op-erigon reached end-of-life on 2026-05-31 and do not support these upgrades. Operators still running them must migrate to op-reth; see the [op-geth/op-erigon to op-reth migration guide](https://github.com/bobanetwork/boba/blob/develop/boba-community/scripts/geth-to-reth/README.md).
+:::
+
+### Supply the Boba Sepolia config files (mandatory)
+
+Because these forks are not yet in the superchain-registry, the activation times must be supplied at runtime rather than relying on the images' built-in Boba Sepolia config:
+
+* op-reth: `--chain=<path>` pointing at [`boba-community/chainspecs/boba-sepolia-chainspec.json`](https://github.com/bobanetwork/boba/blob/develop/boba-community/chainspecs/boba-sepolia-chainspec.json)
+* op-node: `--rollup.config=<path>` pointing at [`boba-community/rollup-configs/boba-sepolia-rollup.json`](https://github.com/bobanetwork/boba/blob/develop/boba-community/rollup-configs/boba-sepolia-rollup.json)
+
+The bundled [`docker-compose-boba-sepolia.yml`](https://github.com/bobanetwork/boba/blob/develop/boba-community/docker-compose-boba-sepolia.yml) in `boba-community/` already mounts these files. Once the forks land in the superchain-registry and the upstream images are rebuilt against it, the built-in config may be used again.
+
+### Verify your configuration
+
+Both clients log their fork schedule at startup.
+
+* Check that Isthmus is set to `1787227200` in the op-reth and op-node startup logs
+* Check that Jovian is set to `1787659200` in the op-reth and op-node startup logs


### PR DESCRIPTION
## Summary

Follow-up to #363, which added the pending Isthmus/Jovian fork times to the Boba Sepolia configs but missed the corresponding operator **notices** page. This adds it.

New file: `boba-docs/dev-docs/notices/89_isthmus-jovian-breaking-changes.md`, following the conventions in that folder — numbered `89` so it sorts above the newest existing notice (`90_fusaka`), with the standard structure (activation dates → `## For Node Operators` → required versions → verify steps).

## Contents

- **Activation dates (Boba Sepolia):** Isthmus + Prague @ `1787227200` (2026-08-20 12:00 UTC), Jovian @ `1787659200` (2026-08-25 12:00 UTC). Mainnet noted as not-yet-scheduled.
- **Required versions:** op-reth `v2.3.1`, op-node `v1.19.0`; note that op-geth/op-erigon are EOL.
- **Key breaking change (called out in a warning):** because these forks are not yet in the superchain-registry, operators must supply the chain spec + rollup config JSON at runtime and not rely on the built-in `--chain=boba-sepolia`. Links point at the `boba-sepolia-chainspec.json` / `boba-sepolia-rollup.json` files added in #363.

## Notes

Branched off the post-merge `develop`; the config files this notice links to are already present there.